### PR TITLE
Harden scripts with dependency checks and repo guardrails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+results/
+logs/
+*.apk
+*.zip
+*.tmp

--- a/config.sh
+++ b/config.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 # ---------------------------------------------------
+#!/usr/bin/env bash
+set -euo pipefail
+trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO" >&2' ERR
 # config.sh
 # Global configuration for DroidHarvester
 # ---------------------------------------------------

--- a/lib/colors.sh
+++ b/lib/colors.sh
@@ -1,3 +1,7 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+set -euo pipefail
+trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO" >&2' ERR
 # ---------------------------------------------------
 # lib/colors.sh
 # Centralized color/format definitions
@@ -9,14 +13,7 @@ if tput setaf 1 >/dev/null 2>&1; then
     GREEN=$(tput setaf 2)
     YELLOW=$(tput setaf 3)
     BLUE=$(tput setaf 4)
-    MAGENTA=$(tput setaf 5)
     CYAN=$(tput setaf 6)
-    WHITE=$(tput setaf 7)
-    GRAY=$(tput setaf 8)
-
-    BOLD=$(tput bold)
-    UNDERLINE=$(tput smul)
-    RESET_UNDERLINE=$(tput rmul)
     NC=$(tput sgr0)  # reset
 else
     # Fallback ANSI escape sequences
@@ -24,13 +21,6 @@ else
     GREEN="\033[0;32m"
     YELLOW="\033[1;33m"
     BLUE="\033[0;34m"
-    MAGENTA="\033[0;35m"
     CYAN="\033[0;36m"
-    WHITE="\033[1;37m"
-    GRAY="\033[0;90m"
-
-    BOLD="\033[1m"
-    UNDERLINE="\033[4m"
-    RESET_UNDERLINE="\033[24m"
     NC="\033[0m"
 fi

--- a/lib/deps.sh
+++ b/lib/deps.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO" >&2' ERR
+
+check_dependencies() {
+    local missing=()
+    for cmd in adb jq sha256sum md5sum sha1sum zip column; do
+        if ! command -v "$cmd" >/dev/null 2>&1; then
+            missing+=("$cmd")
+        fi
+    done
+    if (( ${#missing[@]} )); then
+        for cmd in "${missing[@]}"; do
+            echo "Missing dependency: $cmd - install via 'sudo dnf install -y $cmd'" >&2
+        done
+        exit 1
+    fi
+}

--- a/lib/device.sh
+++ b/lib/device.sh
@@ -1,35 +1,68 @@
-#!/bin/bash
-pick_device() {
-    if [[ -n "$DEVICE" ]]; then
-        # Device already set (via argument or earlier selection)
+#!/usr/bin/env bash
+set -euo pipefail
+trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO" >&2' ERR
+
+# Run adb shell commands with retry and disconnect handling
+adb_shell() {
+    local attempts=0
+    local output
+    while (( attempts < 3 )); do
+        if output=$(adb -s "$DEVICE" shell "$@" 2>/dev/null); then
+            printf '%s\n' "$output"
+            return 0
+        fi
+        ((attempts++))
+        if ! adb devices | awk 'NR>1 && $2=="device" {print $1}' | grep -qx "$DEVICE"; then
+            read -rp "Device disconnected. retry or reselect device? [r/s]: " ans
+            case "$ans" in
+                r|R) continue ;;
+                s|S) choose_device; return 1 ;;
+                *)   log ERROR "E_NO_DEVICE: device unavailable"; return 1 ;;
+            esac
+        fi
+        sleep 1
+    done
+    log ERROR "E_DUMPSYS_FAIL: adb shell $* failed"
+    return 1
+}
+
+# Device selection helper
+# Presents connected devices in a menu and initializes reporting
+# for the chosen device.
+
+choose_device() {
+    local devices
+    devices=$(adb devices | awk 'NR>1 && $2=="device" {print $1}')
+    if [[ -z "$devices" ]]; then
+        log ERROR "E_NO_DEVICE: no devices detected"
         return
     fi
 
-    # Get list of connected devices (skip header line)
-    mapfile -t devices < <(adb devices | awk 'NR>1 && $2=="device" {print $1}')
+    draw_menu_header "Device Selection"
+    local i=1
+    for d in $devices; do
+        echo "  [$i] $d"
+        ((i++))
+    done
+    echo "--------------------------------------------------"
+    read -rp "Select device [1-$((i-1))]: " choice
+    DEVICE=$(echo "$devices" | sed -n "${choice}p")
 
-    if [[ ${#devices[@]} -eq 0 ]]; then
-        log "ERROR: No devices detected."
-        exit 1
+    if [[ -z "$DEVICE" ]]; then
+        log ERROR "Invalid device choice."
+        return
+    fi
 
-    elif [[ ${#devices[@]} -eq 1 ]]; then
-        DEVICE="${devices[0]}"
-        log "INFO: Automatically selected device: $DEVICE"
+    DEVICE_DIR="$RESULTS_DIR/$DEVICE"
+    mkdir -p "$DEVICE_DIR"
+    DEVICE_FINGERPRINT="$(adb_shell getprop ro.product.manufacturer | tr -d '\r') $(adb_shell getprop ro.product.model | tr -d '\r')"
+    export DEVICE_FINGERPRINT
+    init_report
+    log SUCCESS "Using device: $DEVICE"
+    log INFO "Output directory: $DEVICE_DIR"
 
-    else
-        echo ""
-        echo "Connected devices:"
-        for i in "${!devices[@]}"; do
-            printf "  %2d) %s\n" $((i+1)) "${devices[$i]}"
-        done
-
-        read -rp "Select device [1-${#devices[@]}]: " choice
-        if [[ "$choice" =~ ^[0-9]+$ ]] && (( choice>=1 && choice<=${#devices[@]} )); then
-            DEVICE="${devices[$((choice-1))]}"
-            log "INFO: Selected device: $DEVICE"
-        else
-            log "ERROR: Invalid selection."
-            exit 1
-        fi
+    if [[ "${INCLUDE_DEVICE_PROFILE:-false}" == "true" ]]; then
+        adb -s "$DEVICE" shell getprop | tee -a "$LOGFILE" > "$DEVICE_DIR/device_profile.txt"
+        log INFO "Device profile saved: $DEVICE_DIR/device_profile.txt"
     fi
 }

--- a/lib/logging.sh
+++ b/lib/logging.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
+trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO" >&2' ERR
 # ---------------------------------------------------
 # logging.sh - Logging and Usage Helpers
 # ---------------------------------------------------
@@ -17,12 +19,17 @@ if [[ -z "${LOGFILE:-}" ]]; then
     LOGFILE="$LOGS_DIR/harvest_log_$TIMESTAMP.txt"
 fi
 
+export E_NO_DEVICE=1
+export E_PULL_FAIL=2
+export E_DUMPSYS_FAIL=3
+
 # ---------------------------------------------------
 # Logging Function
 # ---------------------------------------------------
 log() {
     local level="$1"; shift
-    local msg="[$(date +'%H:%M:%S')] $*"
+    local msg
+    msg="[$(date +'%H:%M:%S')] $*"
 
     # Strip ANSI codes before writing to logfile (clean text log)
     local clean_msg

--- a/lib/menu_util.sh
+++ b/lib/menu_util.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
+trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO" >&2' ERR
 # ---------------------------------------------------
 # menu_util.sh - Shared Menu Utilities for DroidHarvester
 # ---------------------------------------------------
@@ -47,7 +49,7 @@ read_choice() {
     local choice
 
     while true; do
-        read -rp "➤  Enter selection [1-$max]: " choice
+        read -rp "Enter selection [1-$max]: " choice
         if [[ "$choice" =~ ^[0-9]+$ ]] && (( choice>=1 && choice<=max )); then
             echo "$choice"
             return
@@ -62,7 +64,7 @@ read_choice() {
 # ---------------------------------------------------
 pause() {
     echo
-    read -rp "⏸  Press ENTER to continue..." _
+    read -rp "Press ENTER to continue..." _
 }
 
 # ---------------------------------------------------
@@ -72,7 +74,7 @@ pause() {
 confirm() {
     local prompt="$1"
     echo
-    read -rp "⚠️  $prompt [y/N]: " ans
+    read -rp "WARNING: $prompt [y/N]: " ans
     case "$ans" in
         [Yy]*) return 0 ;;
         *)     return 1 ;;

--- a/make_executable.sh
+++ b/make_executable.sh
@@ -1,13 +1,13 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ---------------------------------------------------
 # make_executable.sh - Ensure all .sh files in this
 # project (and child dirs) are executable
 # ---------------------------------------------------
 
-set -uo pipefail
+set -euo pipefail
+trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO" >&2' ERR
 
 # Colors
-RED="\033[0;31m"
 GREEN="\033[0;32m"
 YELLOW="\033[1;33m"
 BLUE="\033[0;34m"
@@ -15,7 +15,7 @@ NC="\033[0m"
 
 PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-echo -e "${BLUE}🔍 Scanning for .sh files in: $PROJECT_DIR${NC}"
+echo -e "${BLUE}Scanning for .sh files in: $PROJECT_DIR${NC}"
 
 count=0
 changed=0
@@ -25,15 +25,15 @@ while IFS= read -r -d '' file; do
     ((count++))
     if [[ ! -x "$file" ]]; then
         chmod +x "$file"
-        echo -e "${GREEN}✅ Made executable:${NC} $file"
+        echo -e "${GREEN}Made executable:${NC} $file"
         ((changed++))
     else
-        echo -e "${BLUE}✔ Already executable:${NC} $file"
+        echo -e "${BLUE}Already executable:${NC} $file"
     fi
 done < <(find "$PROJECT_DIR" -type f -name "*.sh" -print0)
 
 if [[ $count -eq 0 ]]; then
-    echo -e "${YELLOW}⚠️  No .sh files found in $PROJECT_DIR${NC}"
+    echo -e "${YELLOW}No .sh files found in $PROJECT_DIR${NC}"
     exit 0
 fi
 

--- a/repo_maintenance/fix_git_repo.sh
+++ b/repo_maintenance/fix_git_repo.sh
@@ -1,2 +1,0 @@
-# fix_git_repo.sh
-git status

--- a/repo_maintenance/pre-commit.sh
+++ b/repo_maintenance/pre-commit.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+trap 'echo "pre-commit: error at line $LINENO" >&2' ERR
+
+fail=0
+while IFS= read -r file; do
+    if [[ "$file" == *.apk ]]; then
+        echo "pre-commit: APK files are not allowed ($file)" >&2
+        fail=1
+    fi
+    if [[ -f "$file" ]]; then
+        size=$(stat -c%s "$file")
+        if (( size > 52428800 )); then
+            echo "pre-commit: $file exceeds 50MB" >&2
+            fail=1
+        fi
+    fi
+done < <(git diff --cached --name-only --diff-filter=AM)
+
+exit $fail


### PR DESCRIPTION
## Summary
- add global safety flags and central dependency checking
- retry ADB operations with disconnect handling and provide session-aware menu
- embed session metadata in reports and block committing APKs or large files

## Testing
- `shellcheck run.sh lib/*.sh make_executable.sh repo_maintenance/pre-commit.sh`
- `./run.sh --debug` (menu appeared; aborted)


------
https://chatgpt.com/codex/tasks/task_e_68a8f0ce21088327ad9402cc55b710ce