### PR TITLE
Add README with usage and directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# DroidHarvester
+
+DroidHarvester is an interactive console for collecting APKs from Android devices, extracting metadata, and generating analyst reports.
+
+## Prerequisites
+
+* Android Debug Bridge (`adb`) with a device connected
+* `jq`, `zip`, `column`
+* `sha256sum`, `sha1sum`, `md5sum`
+
+## Basic Usage
+
+```bash
+./run.sh           # launch the menu-driven interface
+./run.sh --debug   # enable verbose logging
+```
+
+## Logs and Results
+
+Logs are written to the `logs/` directory (e.g., `logs/harvest_log_<timestamp>.txt`).
+
+Harvested APK metadata and reports are stored in `results/` with CSV, JSON, and TXT formats (e.g., `results/apks_report_<timestamp>.<ext>`).


### PR DESCRIPTION
## Summary
- Add project README outlining purpose, prerequisites, and usage
- Document logging and results directory structure

## Testing
- `bash -n run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a8f8b89d108327b9ffee98f1d85556