### PR TITLE
Add README with usage and directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# DroidHarvester
+
+DroidHarvester provides an interactive shell for analysts to collect APKs from a connected Android device, extract metadata, and generate reports.
+
+## Prerequisites
+
+- Android Debug Bridge (`adb`) with a device connected
+- Command‑line utilities: `jq`, `zip`, `column`
+- Hash tools: `sha256sum`, `sha1sum`, `md5sum`
+
+## Usage
+
+```bash
+./run.sh           # launch the menu-driven interface
+./run.sh --debug   # enable verbose logging
+```
+
+Environment variables may override defaults (e.g., `LOG_LEVEL=DEBUG ./run.sh`). The full configuration and default target package list live in `config.sh`, and extra packages can be supplied via `custom_packages.txt`.
+
+## Logs and Results
+
+Execution logs are written to `logs/harvest_log_<timestamp>.txt`.
+
+Harvested APK metadata and reports are stored in `results/apks_report_<timestamp>.<ext>` with CSV, JSON, and TXT variants.


### PR DESCRIPTION
## Summary
- Expand README with configuration details and environment overrides
- Clarify logging and results directories

## Testing
- `bash -n run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a8f8b89d108327b9ffee98f1d85556