### PR TITLE
fix: remove redundant sourcing in menu util

### DIFF
--- a/lib/menu_util.sh
+++ b/lib/menu_util.sh
@@ -9,9 +9,6 @@ trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO" >&2' ERR
 # in SOC-style environments where precision matters.
 # ---------------------------------------------------
 
-source "$SCRIPT_DIR/lib/colors.sh"
-source "$SCRIPT_DIR/lib/logging.sh"
-
 # ---------------------------------------------------
 # Draw Menu Header
 # ---------------------------------------------------


### PR DESCRIPTION
## Summary
- avoid sourcing logging or colors in `menu_util.sh`

## Testing
- `bash -n lib/menu_util.sh`
- `bash -n run.sh`
- `bash -c 'SCRIPT_DIR=$(pwd); source lib/logging.sh; source lib/menu_util.sh; log INFO test'`


------
https://chatgpt.com/codex/tasks/task_e_68a8f8b4ebb883278c0eb2d40fe84faa