### PR TITLE
chore: standardize config header

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -1,8 +1,7 @@
-#!/bin/bash
-# ---------------------------------------------------
 #!/usr/bin/env bash
 set -euo pipefail
 trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO" >&2' ERR
+# ---------------------------------------------------
 # config.sh
 # Global configuration for DroidHarvester
 # ---------------------------------------------------
@@ -57,6 +56,7 @@ fi
 
 # Hash algorithms to compute
 # Extendable: add "blake2b" or "sha512" if required
+# shellcheck disable=SC2034  # referenced externally
 HASH_ALGOS=("sha256" "sha1" "md5")
 
 # File size threshold (bytes) for hash computation (0 = no limit)
@@ -68,6 +68,7 @@ HASH_ALGOS=("sha256" "sha1" "md5")
 # ===============================
 
 # Report formats to generate (txt, csv, json, html if supported)
+# shellcheck disable=SC2034  # referenced externally
 REPORT_FORMATS=("txt" "csv" "json")
 
 # Log level: INFO | DEBUG | WARN | ERROR


### PR DESCRIPTION
## Summary
- replace hard-coded bash shebang with portable header and error trap in `config.sh`
- annotate array variables with shellcheck directive to document external use

## Testing
- `bash -n config.sh`
- `shellcheck config.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a8f8b41c988327bbe9cf725ddfb6f7