### PR TITLE
feat: show device and report in menu header

### DIFF
--- a/lib/menu_util.sh
+++ b/lib/menu_util.sh
@@ -14,15 +14,24 @@ source "$SCRIPT_DIR/lib/logging.sh"
 
 # ---------------------------------------------------
 # Draw Menu Header
+# Optional args: <title> [device] [report]
 # ---------------------------------------------------
 draw_menu_header() {
     local title="$1"
+    local device_arg="${2-__unset__}"
+    local report_arg="${3-__unset__}"
     echo
     echo "============================================================"
     printf " %-58s\n" "DROIDHARVESTER // ANALYST CONTROL INTERFACE"
     echo "------------------------------------------------------------"
     printf " %-58s\n" "SESSION : $(date '+%Y-%m-%d %H:%M:%S')"
     printf " %-58s\n" "MODULE  : $title"
+    if [[ "$device_arg" != "__unset__" ]]; then
+        printf " %-58s\n" "DEVICE  : ${device_arg:-Not selected}"
+    fi
+    if [[ "$report_arg" != "__unset__" ]]; then
+        printf " %-58s\n" "REPORT  : ${report_arg:-None}"
+    fi
     echo "============================================================"
 }
 

--- a/run.sh
+++ b/run.sh
@@ -218,9 +218,11 @@ session_metadata
 
 while true; do
     LAST_TXT_REPORT=$(latest_report)
-    draw_menu_header "DroidHarvester Main Menu"
-    echo " Device      : ${DEVICE:-Not selected}"
-    echo " Last report : ${LAST_TXT_REPORT:-None}"
+    header_report=""
+    if [[ -n "$LAST_TXT_REPORT" ]]; then
+        header_report="$(basename "$LAST_TXT_REPORT")"
+    fi
+    draw_menu_header "DroidHarvester Main Menu" "$DEVICE" "$header_report"
     echo " Harvested   : found $PKGS_FOUND pulled $PKGS_PULLED"
     echo " Targets     : ${#TARGET_PACKAGES[@]} default / ${#CUSTOM_PACKAGES[@]} custom"
     echo


### PR DESCRIPTION
## Summary
- allow draw_menu_header to show optional device and report info
- pass current device and latest report filename from main loop, removing extra echo lines
- display only report filename in header for readability

## Testing
- `shellcheck -x lib/menu_util.sh run.sh`
- `bash -n lib/menu_util.sh run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a8f8b62bc88327a0fe511ef76ae81a