### PR TITLE
Use CSV-safe printf

### DIFF
--- a/lib/metadata.sh
+++ b/lib/metadata.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO" >&2' ERR
+
+csv_escape() {
+    local q='"'
+    local str=${1//$q/$q$q}
+    printf '"%s"' "$str"
+}
+
 apk_metadata() {
     local pkg="$1"
     local outfile="$2"
@@ -65,7 +72,24 @@ apk_metadata() {
         # -----------------------------
         # CSV Report
         # -----------------------------
-        echo "$pkg,$outfile,$sha256,$sha1,$md5,$size,$perms,$mtime,$version,$versionCode,$targetSdk,$installer,$firstInstall,$lastUpdate,$uid,$installType,TBD" >> "$REPORT"
+        printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
+            "$(csv_escape "$pkg")" \
+            "$(csv_escape "$outfile")" \
+            "$(csv_escape "$sha256")" \
+            "$(csv_escape "$sha1")" \
+            "$(csv_escape "$md5")" \
+            "$(csv_escape "$size")" \
+            "$(csv_escape "$perms")" \
+            "$(csv_escape "$mtime")" \
+            "$(csv_escape "$version")" \
+            "$(csv_escape "$versionCode")" \
+            "$(csv_escape "$targetSdk")" \
+            "$(csv_escape "$installer")" \
+            "$(csv_escape "$firstInstall")" \
+            "$(csv_escape "$lastUpdate")" \
+            "$(csv_escape "$uid")" \
+            "$(csv_escape "$installType")" \
+            "$(csv_escape "TBD")" >> "$REPORT"
 
         append_txt_report "$pkg" "$outfile" "$sha256" "$sha1" "$md5" "$size" "$version" "$versionCode" "$targetSdk" "$installer" "$installType"
 


### PR DESCRIPTION
## Summary
- ensure CSV output is properly quoted by adding a helper to escape fields
- replace `echo` with `printf` for reliable CSV line generation
- optimize CSV escaping with pure Bash parameter expansion

## Testing
- `shellcheck lib/metadata.sh`
- `bash -n lib/metadata.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a8f8b794c483279b18d92259a5766e