### PR TITLE
Preserve exit status in log function

### DIFF
--- a/lib/apk_utils.sh
+++ b/lib/apk_utils.sh
@@ -37,7 +37,7 @@ pull_apk() {
 
     # Confirm file exists on device
     if ! adb -s "$DEVICE" shell "[ -f \"$apk_path\" ]" >/dev/null 2>&1; then
-        log WARN "File not found on device: $apk_path"
+        log WARN "File not found on device: $apk_path" || true
         return 1
     fi
 
@@ -55,10 +55,10 @@ pull_apk() {
                 success=1
                 break
             else
-                log WARN "Pulled file is empty: $outfile"
+                log WARN "Pulled file is empty: $outfile" || true
             fi
         else
-            log WARN "Pull command failed for $apk_path"
+            log WARN "Pull command failed for $apk_path" || true
             if ! adb devices | awk 'NR>1 && $2=="device" {print $1}' | grep -qx "$DEVICE"; then
                 read -rp "Device disconnected. retry or reselect device? [r/s]: " ans
                 case "$ans" in

--- a/lib/logging.sh
+++ b/lib/logging.sh
@@ -27,6 +27,7 @@ export E_DUMPSYS_FAIL=3
 # Logging Function
 # ---------------------------------------------------
 log() {
+    local prev_status=$?
     local level="$1"; shift
     local msg
     msg="[$(date +'%H:%M:%S')] $*"
@@ -63,6 +64,7 @@ log() {
             echo "$clean_msg" >> "$LOGFILE"
             ;;
     esac
+    return "$prev_status"
 }
 
 # ---------------------------------------------------

--- a/lib/menu_util.sh
+++ b/lib/menu_util.sh
@@ -54,7 +54,7 @@ read_choice() {
             echo "$choice"
             return
         else
-            log WARN "Invalid input. Enter a number between 1 and $max."
+            log WARN "Invalid input. Enter a number between 1 and $max." || true
         fi
     done
 }

--- a/run.sh
+++ b/run.sh
@@ -78,7 +78,7 @@ scan_apps() {
         if grep -Fq -- "$pkg" <<< "$pkg_list"; then
             log SUCCESS "Found: $pkg"
         else
-            log WARN "Not installed: $pkg"
+            log WARN "Not installed: $pkg" || true
         fi
     done
 }
@@ -90,7 +90,7 @@ add_custom_package() {
         echo "$pkg" >> "$CUSTOM_PACKAGES_FILE"
         log SUCCESS "Added custom package: $pkg"
     else
-        log WARN "No package entered."
+        log WARN "No package entered." || true
     fi
 }
 
@@ -111,18 +111,20 @@ harvest() {
         if [[ -n "$apk_paths" ]]; then
             ((PKGS_FOUND++))
             local pulled=0
-            while read -r path; do
-                [[ -z "$path" ]] && continue
-                log INFO "Found APK: $path"
-                outfile=$(pull_apk "$pkg" "$path")
-                if [[ -n "$outfile" ]]; then
-                    pulled=1
-                    apk_metadata "$pkg" "$outfile"
-                fi
-            done <<< "$apk_paths"
+              while read -r path; do
+                  if [[ -z "$path" ]]; then
+                      continue
+                  fi
+                  log INFO "Found APK: $path"
+                  outfile=$(pull_apk "$pkg" "$path")
+                  if [[ -n "$outfile" ]]; then
+                      pulled=1
+                      apk_metadata "$pkg" "$outfile"
+                  fi
+              done <<< "$apk_paths"
             ((pulled)) && ((PKGS_PULLED++))
         else
-            log WARN "Not installed: $pkg"
+            log WARN "Not installed: $pkg" || true
         fi
     done
 
@@ -150,7 +152,7 @@ search_installed_apps() {
     if [[ -n "$results" ]]; then
         echo "$results"
     else
-        log WARN "No packages match '$keyword'"
+        log WARN "No packages match '$keyword'" || true
     fi
 }
 
@@ -167,7 +169,7 @@ view_report() {
         echo "--------------------------------------------------"
         head -n 40 "$latest"
         echo "--------------------------------------------------"
-        log INFO "Full report: $latest"
+        log INFO "Full report: $latest" || true
     fi
 }
 


### PR DESCRIPTION
## Summary
- Preserve previous command's exit status in `log` and return it after writing log messages
- Guard warning logs and menu input validation with `|| true` so preserved statuses don't abort execution
- Refactor APK path loop to avoid non-zero statuses before logging

## Testing
- `bash repo_maintenance/pre-commit.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a8f8b37ea083278f933a9845074117