### PR TITLE
Cleanup temporary reports on exit

### DIFF
--- a/lib/report.sh
+++ b/lib/report.sh
@@ -141,5 +141,9 @@ finalize_report() {
     if [[ "$mode" == *"txt"* || "$mode" == "all" ]]; then
         log INFO "TXT report saved: $TXT_REPORT"
     fi
-    rm -f "$JSON_REPORT.tmp"
+    cleanup_reports
+}
+
+cleanup_reports() {
+    [[ -n "${JSON_REPORT:-}" ]] && rm -f "$JSON_REPORT.tmp"
 }

--- a/run.sh
+++ b/run.sh
@@ -40,6 +40,8 @@ REPORT="$RESULTS_DIR/apks_report_$TIMESTAMP.csv"
 JSON_REPORT="$RESULTS_DIR/apks_report_$TIMESTAMP.json"
 TXT_REPORT="$RESULTS_DIR/apks_report_$TIMESTAMP.txt"
 
+trap cleanup_reports EXIT
+
 DEVICE=""
 CUSTOM_PACKAGES_FILE="$SCRIPT_DIR/custom_packages.txt"
 CUSTOM_PACKAGES=()


### PR DESCRIPTION
## Summary
- add a cleanup_reports helper that removes the temporary JSON report
- ensure run.sh always calls cleanup_reports on exit so temp files don't persist

## Testing
- `shellcheck lib/report.sh run.sh`
- `bash repo_maintenance/pre-commit.sh`
- `bash -n lib/report.sh run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a8fbfc62b48327a85b4e134a2fc3eb