### PR TITLE
Ensure ERR traps propagate to functions

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+set -E
 trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO" >&2' ERR
 # ---------------------------------------------------
 # config.sh

--- a/lib/apk_utils.sh
+++ b/lib/apk_utils.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+set -E
 trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO" >&2' ERR
 # ---------------------------------------------------
 # lib/apk_utils.sh

--- a/lib/colors.sh
+++ b/lib/colors.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034
 set -euo pipefail
+set -E
 trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO" >&2' ERR
 # ---------------------------------------------------
 # lib/colors.sh

--- a/lib/deps.sh
+++ b/lib/deps.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+set -E
 trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO" >&2' ERR
 
 check_dependencies() {

--- a/lib/device.sh
+++ b/lib/device.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+set -E
 trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO" >&2' ERR
 
 # Run adb shell commands with retry and disconnect handling

--- a/lib/logging.sh
+++ b/lib/logging.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+set -E
 trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO" >&2' ERR
 # ---------------------------------------------------
 # logging.sh - Logging and Usage Helpers

--- a/lib/menu_util.sh
+++ b/lib/menu_util.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+set -E
 trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO" >&2' ERR
 # ---------------------------------------------------
 # menu_util.sh - Shared Menu Utilities for DroidHarvester

--- a/lib/metadata.sh
+++ b/lib/metadata.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+set -E
 trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO" >&2' ERR
 
 csv_escape() {

--- a/lib/report.sh
+++ b/lib/report.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+set -E
 trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO" >&2' ERR
 # ---------------------------------------------------
 # report.sh - Report initialization and finalization

--- a/make_executable.sh
+++ b/make_executable.sh
@@ -5,6 +5,7 @@
 # ---------------------------------------------------
 
 set -euo pipefail
+set -E
 trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO" >&2' ERR
 
 # Colors

--- a/repo_maintenance/pre-commit.sh
+++ b/repo_maintenance/pre-commit.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+set -E
 trap 'echo "pre-commit: error at line $LINENO" >&2' ERR
 
 fail=0

--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,7 @@
 # ---------------------------------------------------
 
 set -euo pipefail
+set -E
 trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO" >&2' ERR
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
## Summary
- enable `set -E` in run.sh and all sourced helper scripts so ERR traps fire inside shell functions
- centralize consistent error handling across utilities

## Testing
- `bash repo_maintenance/pre-commit.sh`
- `bash /tmp/test_err.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a8fbfb6e5c832786ef5553ee01a371