### PR TITLE
Gracefully handle missing APK paths

### DIFF
--- a/lib/apk_utils.sh
+++ b/lib/apk_utils.sh
@@ -15,8 +15,8 @@ get_apk_paths() {
     paths=$(adb_shell pm path "$pkg" 2>/dev/null | tr -d '\r' | sed 's/package://g' || true)
 
     if [[ -z "$paths" ]]; then
-        log ERROR "No APK paths found for package $pkg"
-        return 1
+        log WARN "No APK paths found for package $pkg"
+        return 0
     fi
 
     echo "$paths"

--- a/run.sh
+++ b/run.sh
@@ -107,7 +107,7 @@ harvest() {
     PKGS_PULLED=0
     for pkg in "${all_pkgs[@]}"; do
         log INFO "Checking $pkg..."
-        apk_paths=$(get_apk_paths "$pkg")
+        apk_paths=$(get_apk_paths "$pkg" || true)
         if [[ -n "$apk_paths" ]]; then
             ((PKGS_FOUND++))
             local pulled=0


### PR DESCRIPTION
## Summary
- Return success with a warning when no APK paths are found
- Prevent harvest loop from aborting if `get_apk_paths` fails

## Testing
- `bash -n lib/apk_utils.sh run.sh && echo "syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68a8fbfa64248327897be0d8f62390f1