### PR TITLE
Enhance pre-commit hook with additional git hygiene checks

### DIFF
--- a/repo_maintenance/pre-commit.sh
+++ b/repo_maintenance/pre-commit.sh
@@ -1,21 +1,66 @@
 #!/usr/bin/env bash
 set -euo pipefail
 set -E
-trap 'echo "pre-commit: error at line $LINENO" >&2' ERR
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOGFILE="$SCRIPT_DIR/logs/pre-commit_$(date +%Y%m%d_%H%M%S).log"
+# shellcheck disable=SC1090
+source "$SCRIPT_DIR/lib/logging.sh"
+
+trap 'log ERROR "pre-commit: error at line $LINENO"' ERR
 
 fail=0
-while IFS= read -r file; do
+
+# Ensure there are no unresolved merge conflicts
+if [[ -n $(git ls-files -u) ]]; then
+    log ERROR "Unmerged files detected. Resolve conflicts before committing."
+    git ls-files -u >&2
+    exit 1
+fi
+
+mapfile -t files < <(git diff --cached --name-only --diff-filter=AM)
+if [[ ${#files[@]} -eq 0 ]]; then
+    log INFO "No staged files to check."
+    exit 0
+fi
+
+log INFO "Checking ${#files[@]} staged files..."
+
+for file in "${files[@]}"; do
+    log INFO "Scanning $file"
     if [[ "$file" == *.apk ]]; then
-        echo "pre-commit: APK files are not allowed ($file)" >&2
+        log ERROR "APK files are not allowed ($file)"
         fail=1
     fi
     if [[ -f "$file" ]]; then
         size=$(stat -c%s "$file")
         if (( size > 52428800 )); then
-            echo "pre-commit: $file exceeds 50MB" >&2
+            log ERROR "$file exceeds 50MB"
             fail=1
         fi
-    fi
-done < <(git diff --cached --name-only --diff-filter=AM)
 
-exit $fail
+        # Only run text-based checks on non-binary files
+        if grep -Iq . "$file"; then
+            if grep -q $'\r' "$file"; then
+                log ERROR "CRLF line endings found in $file"
+                fail=1
+            fi
+            if grep -n -E '[ \t]+$' "$file" >/dev/null; then
+                log ERROR "Trailing whitespace in $file"
+                fail=1
+            fi
+            if grep -n -E '^(<<<<<<<|=======|>>>>>>>|\|\|\|\|\|\|)' "$file" >/dev/null; then
+                log ERROR "Merge conflict markers detected in $file"
+                fail=1
+            fi
+        fi
+    fi
+done
+
+if (( fail )); then
+    log ERROR "Pre-commit checks failed."
+    exit $fail
+fi
+
+log SUCCESS "Pre-commit checks passed."
+exit 0


### PR DESCRIPTION
## Summary
- detect unmerged files and exit before commit
- run line-ending, trailing whitespace, and merge marker checks on staged text files
- adopt project logging utilities for clearer pre-commit feedback
- record pre-commit output in timestamped logs/pre-commit_*.log files

## Testing
- `bash repo_maintenance/pre-commit.sh`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68a90186e9c0832780f569b15dba44b1