### PR TITLE
Bootstrap config and harden APK path test script

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -16,6 +16,9 @@ trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO" >&2' ERR
 #   - Custom packages may be provided via external file.
 # ---------------------------------------------------
 
+# Determine repository root if caller has not set SCRIPT_DIR
+: "${SCRIPT_DIR:="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"}"
+
 # ===============================
 # I. OUTPUT DIRECTORIES
 # ===============================


### PR DESCRIPTION
## Summary
- Prevent `config.sh` from failing when `SCRIPT_DIR` is unset by auto-detecting its location
- Improve `test_get_apk_paths.sh` with explicit exit codes, device auto-selection, and `--device`/`--package` flags

## Testing
- `bash -n scripts/test_get_apk_paths.sh`
- `./scripts/test_get_apk_paths.sh` *(fails: no devices detected)*

------
https://chatgpt.com/codex/tasks/task_e_68a915d864688327b6b59384988274dc