### PR TITLE
Fix early initialization and robust metadata extraction

### DIFF
--- a/lib/actions/choose_device.sh
+++ b/lib/actions/choose_device.sh
@@ -34,11 +34,13 @@ choose_device() {
     DEVICE_FINGERPRINT="$(adb_shell getprop ro.product.manufacturer | tr -d '\r') $(adb_shell getprop ro.product.model | tr -d '\r')"
     export DEVICE_FINGERPRINT
     init_report
-    LOG_DEV="$DEVICE" log SUCCESS "Using device: $DEVICE"
-    LOG_DEV="$DEVICE" log INFO "Output directory: $DEVICE_DIR"
+    LOG_DEV="$DEVICE"
+    log SUCCESS "Using device: $DEVICE"
+    log INFO "Output directory: $DEVICE_DIR"
 
     if [[ "${INCLUDE_DEVICE_PROFILE:-false}" == "true" ]]; then
         adb -s "$DEVICE" shell getprop | tee -a "$LOGFILE" > "$DEVICE_DIR/device_profile.txt"
-        LOG_DEV="$DEVICE" log INFO "Device profile saved: $DEVICE_DIR/device_profile.txt"
+        log INFO "Device profile saved: $DEVICE_DIR/device_profile.txt"
     fi
+    unset LOG_DEV
 }

--- a/lib/actions/harvest.sh
+++ b/lib/actions/harvest.sh
@@ -94,7 +94,7 @@ _pull_one_path() {
     fi
 
     # Record metadata for this artifact
-    apk_metadata "$pkg" "$outfile" || {
+    apk_metadata "$pkg" "$outfile" "$path" || {
         LOG_PKG="$pkg" log WARN "metadata_failed file=${outfile}"
         return 1
     }

--- a/lib/core/logging.sh
+++ b/lib/core/logging.sh
@@ -34,7 +34,8 @@ log() {
     local msg="$*"
     local ts_human="$(date +'%H:%M:%S')"
     local ts_iso="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-    local structured="ts=$ts_iso lvl=$level sid=${SESSION_ID:- -} code=${LOG_CODE:- -} comp=${LOG_COMP:- -} func=${LOG_FUNC:- -} dev=${DEVICE:- -} pkg=${LOG_PKG:- -} apk=${LOG_APK:- -} dur_ms=${LOG_DUR_MS:- -} rc=${LOG_RC:- -} msg=\"$msg\""
+    local dev_field="${LOG_DEV:-${DEVICE:- -}}"
+    local structured="ts=$ts_iso lvl=$level sid=${SESSION_ID:- -} code=${LOG_CODE:- -} comp=${LOG_COMP:- -} func=${LOG_FUNC:- -} dev=${dev_field} pkg=${LOG_PKG:- -} apk=${LOG_APK:- -} dur_ms=${LOG_DUR_MS:- -} rc=${LOG_RC:- -} msg=\"$msg\""
     local color prefix
     case "$level" in
         DEBUG)

--- a/run.sh
+++ b/run.sh
@@ -15,6 +15,16 @@ SCRIPT_DIR="$REPO_ROOT"
 LOG_DIR="$REPO_ROOT/logs"
 mkdir -p "$LOG_DIR"
 
+DEVICE=""
+LOG_LEVEL="INFO"
+DH_DEBUG=0
+
+# Load error/logging helpers early so option parsing can use them
+# shellcheck disable=SC1090
+source "$REPO_ROOT/lib/core/errors.sh"
+# shellcheck disable=SC1090
+source "$REPO_ROOT/lib/core/logging.sh"
+
 usage() {
     cat <<USAGE
 Usage: $0 [--device ID] [--debug] [-h|--help]
@@ -23,9 +33,6 @@ Usage: $0 [--device ID] [--debug] [-h|--help]
 USAGE
 }
 
-DEVICE=""
-LOG_LEVEL="INFO"
-DH_DEBUG=0
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --device) DEVICE="${2:-}"; shift 2;;
@@ -40,7 +47,7 @@ export LOG_LEVEL DH_DEBUG
 source "$REPO_ROOT/config.sh"
 
 # shellcheck disable=SC1090
-for lib in core/errors core/logging core/trace core/deps core/device core/session menu/menu_util menu/header io/apk_utils io/report io/find_latest analysis/metadata; do
+for lib in core/trace core/deps core/device core/session menu/menu_util menu/header io/apk_utils io/report io/find_latest analysis/metadata; do
     source "$REPO_ROOT/lib/$lib.sh"
 done
 # shellcheck disable=SC1090


### PR DESCRIPTION
## Summary
- load error and logging helpers before argument parsing
- honor LOG_DEV in log output and clean up choose_device
- make metadata parsing resilient and use original device paths for install-type detection

## Testing
- `bash -n run.sh lib/core/logging.sh lib/actions/harvest.sh lib/actions/choose_device.sh lib/analysis/metadata.sh`
- `./run.sh --help`

------
https://chatgpt.com/codex/tasks/task_e_68a916693b388327a92499a03beece7a