### PR TITLE
Refactor ADB helpers, harden tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,22 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
 
 jobs:
-  shellcheck:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install shellcheck
-        run: sudo apt-get update && sudo apt-get install -y shellcheck
-      - name: Run shellcheck
-        run: shellcheck $(git ls-files '*.sh') || true
-  tests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y shellcheck ripgrep
+      - name: Shellcheck
+        run: shellcheck $(git ls-files '*.sh')
       - name: Run tests
-        run: tests/run.sh
+        run: |
+          ./tests/run.sh
+      - name: Guard forbidden strings
+        run: |
+          ! rg -n 'get-transport-id'
+          ! rg -n 'timeout .*adb_retry'

--- a/README.md
+++ b/README.md
@@ -14,11 +14,21 @@ Standalone diagnostic scripts live at `scripts/adb_apk_diag.sh` and `scripts/adb
 
 ## Device selection
 
-Scripts auto-detect the first attached device and trim any stray whitespace or carriage returns from the serial number. Override detection with `DEV=<serial>`.
+DroidHarvester auto-detects a single connected device and normalizes the
+serial (stripping spaces and carriage returns). Override detection with
+`DEV=<serial>`. If multiple devices are attached, set `DEV` or use the
+interactive menu in `run.sh` to choose one.
 
-If multiple devices are connected, set `DEV` explicitly or use the interactive menu in `run.sh`. When a device shows as `unauthorized` or `offline`, run:
+If ADB reports the device as `unauthorized` or `offline`, run:
 
 ```
 adb kill-server
 adb devices    # accept the RSA prompt on the device
 ```
+
+## Pull limitations
+
+Retail builds often block direct pulls from `/data/app`. The tools try a
+fallback copy to `/data/local/tmp`; if that also fails you'll see a
+`Permission denied` message, but the session continues and still produces
+a report.

--- a/lib/actions/choose_device.sh
+++ b/lib/actions/choose_device.sh
@@ -31,7 +31,7 @@ choose_device() {
         return
     fi
     DEVICE="${dev_array[choice-1]}"
-    update_adb_flags
+    set_device "$DEVICE" || { log ERROR "failed to set device"; return; }
 
     DEVICE_DIR="$RESULTS_DIR/$DEVICE"
     mkdir -p "$DEVICE_DIR"
@@ -43,7 +43,7 @@ choose_device() {
     log INFO "Output directory: $DEVICE_DIR"
 
     if [[ "${INCLUDE_DEVICE_PROFILE:-false}" == "true" ]]; then
-        adb $ADB_FLAGS shell getprop | tee -a "$LOGFILE" > "$DEVICE_DIR/device_profile.txt"
+        adb_shell getprop | tee -a "$LOGFILE" > "$DEVICE_DIR/device_profile.txt"
         log INFO "Device profile saved: $DEVICE_DIR/device_profile.txt"
     fi
     unset LOG_DEV

--- a/lib/core/errors.sh
+++ b/lib/core/errors.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 set -E
-trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO: $BASH_COMMAND" >&2' ERR
+trap 'echo "ERROR: ${BASH_SOURCE[0]:-?}:$LINENO: $BASH_COMMAND" >&2' ERR
 # ---------------------------------------------------
 # errors.sh - central error codes and helpers
 # ---------------------------------------------------

--- a/lib/core/logging.sh
+++ b/lib/core/logging.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 set -E
-trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO: $BASH_COMMAND" >&2' ERR
+trap 'echo "ERROR: ${BASH_SOURCE[0]:-?}:$LINENO: $BASH_COMMAND" >&2' ERR
 # ---------------------------------------------------
 # logging.sh - lightweight structured logging
 # ---------------------------------------------------

--- a/lib/core/trace.sh
+++ b/lib/core/trace.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 set -E
-trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO" >&2' ERR
+trap 'echo "ERROR: ${BASH_SOURCE[0]:-?}:$LINENO" >&2' ERR
 # ---------------------------------------------------
 # trace.sh - tracing helpers
 # ---------------------------------------------------

--- a/run.sh
+++ b/run.sh
@@ -67,24 +67,19 @@ fi
 
 # Resolve device if pre-set or auto-pick single attached device
 if [[ -n "${DEVICE}" ]]; then
-    DEVICE="$(printf '%s' "$DEVICE" | tr -d '\r' | xargs)"
+    DEVICE="$(normalize_serial "$DEVICE")"
     DEVICE="$(device_pick_or_fail "$DEVICE")"
+    set_device "$DEVICE" || DEVICE=""
 else
     mapfile -t _devs < <(device_list_connected)
     if (( ${#_devs[@]} == 1 )); then
-        DEVICE="${_devs[0]}"
+        set_device "${_devs[0]}" || true
     fi
 fi
 
 if [[ -n "$DEVICE" ]]; then
-    # Ensure it's really usable
     if ! assert_device_ready "$DEVICE"; then
         DEVICE=""
-    else
-        # Set common ADB flags if helper exists
-        if type update_adb_flags >/dev/null 2>&1; then
-            update_adb_flags
-        fi
     fi
 fi
 

--- a/scripts/adb_apk_diag.sh
+++ b/scripts/adb_apk_diag.sh
@@ -6,14 +6,18 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # Shared helpers
 # shellcheck disable=SC1090
+source "$ROOT/lib/core/logging.sh"
+# shellcheck disable=SC1090
 source "$ROOT/lib/io/apk_utils.sh"
+# shellcheck disable=SC1090
+source "$ROOT/lib/core/trace.sh"
 # shellcheck disable=SC1090
 source "$ROOT/lib/core/device.sh"
 
 # ---- Device resolution -------------------------------------------------------
 if [[ -z "${DEV:-}" ]]; then
   if tmp_dev="$(get_normalized_serial)"; then
-    DEV="$tmp_dev"
+    set_device "$tmp_dev"
   else
     rc=$?
     case "$rc" in
@@ -25,22 +29,10 @@ if [[ -z "${DEV:-}" ]]; then
     exit 1
   fi
 else
-  DEV="$(printf '%s' "$DEV" | tr -d '\r' | xargs)"
+  set_device "$DEV" || true
 fi
 
-DEVICE="$DEV"
 assert_device_ready "$DEVICE"
-
-# Prefer centralized ADB flags if available
-if type update_adb_flags >/dev/null 2>&1; then
-  update_adb_flags
-fi
-
-if [[ "${DEBUG:-0}" == "1" ]]; then
-  printf '[DEBUG] DEV="%s"\n' "$DEV"
-  printf '[DEBUG] DEV bytes: '
-  printf '%s' "$DEV" | hexdump -C | sed -n '1p'
-fi
 
 # ---- Working dirs ------------------------------------------------------------
 base="$ROOT/results/$DEVICE"

--- a/scripts/adb_health.sh
+++ b/scripts/adb_health.sh
@@ -16,7 +16,7 @@ source "$ROOT/lib/core/device.sh"
 DEVICE="${1:-}"
 if [[ -z "$DEVICE" ]]; then
   if tmp_dev="$(get_normalized_serial)"; then
-    DEVICE="$tmp_dev"
+    set_device "$tmp_dev"
   else
     rc=$?
     case "$rc" in
@@ -28,35 +28,21 @@ if [[ -z "$DEVICE" ]]; then
     exit 1
   fi
 else
-  DEVICE="$(printf '%s' "$DEVICE" | tr -d '\r' | xargs)"
+  set_device "$DEVICE" || true
 fi
 
 assert_device_ready "$DEVICE"
 
-# Prefer centralized ADB flags if available
-if type update_adb_flags >/dev/null 2>&1; then
-  update_adb_flags
-else
-  export ADB_FLAGS="-s $DEVICE"
-fi
-
 LOG_COMP="health"
 
 log INFO "adb get-state"
-adb ${ADB_FLAGS:-} get-state
+adb_get_state >/dev/null 2>&1
 
-log INFO "adb -s $DEVICE shell echo OK"
-adb ${ADB_FLAGS:-} shell echo OK
+log INFO "adb shell echo OK"
+adb_shell echo OK >/dev/null
 
 log INFO "device df"
-adb ${ADB_FLAGS:-} shell df
+adb_shell df >/dev/null
 
 log INFO "host df"
 df -h "${HOME:-/}" || df -h
-
-# Optional: show normalized serial bytes when debugging
-if [[ "${DEBUG:-0}" == "1" ]]; then
-  printf '[DEBUG] DEVICE="%s"\n' "$DEVICE"
-  printf '[DEBUG] DEVICE bytes: '
-  printf '%s' "$DEVICE" | hexdump -C | sed -n '1p'
-fi

--- a/scripts/archive/dev_wrapper_selftest.sh
+++ b/scripts/archive/dev_wrapper_selftest.sh
@@ -71,7 +71,7 @@ report() {
 
   # adb_retry missing "--"
   set +e
-  adb_retry 1 0 label echo hi >/dev/null 2>&1; rc=$?
+  adb_retry 1 1 0 label echo hi >/dev/null 2>&1; rc=$?
   set -e
   report $rc 127 "adb_retry missing --"
 
@@ -90,7 +90,7 @@ SH
   PATH="$TMPDIR:$PATH:$PATH"
   DEVICE="test"
   set +e
-  adb_retry 5 0 retrytest -- get-state >/dev/null 2>>"$LOG_FILE.log"; rc=$?
+  adb_retry 1 5 0 retrytest -- get-state >/dev/null 2>>"$LOG_FILE.log"; rc=$?
   set -e
   report $rc 0 "adb_retry succeeds after retries"
   if ! grep -q 'attempts=3' "$LOG_FILE.log"; then

--- a/steps/generate_apk_metadata.sh
+++ b/steps/generate_apk_metadata.sh
@@ -32,7 +32,6 @@ csv_escape() {
 }
 
 if [[ -f "$outfile" ]]; then
-    local sha256 sha1 md5 size perms mtime
     sha256=$(sha256sum "$outfile" | awk '{print $1}')
     sha1=$(sha1sum "$outfile" | awk '{print $1}')
     md5=$(md5sum "$outfile" | awk '{print $1}')
@@ -40,16 +39,15 @@ if [[ -f "$outfile" ]]; then
     perms=$(stat -c%A "$outfile")
     mtime=$(stat -c%y "$outfile")
 
-    local version="unknown"
-    local versionCode="unknown"
-    local targetSdk="unknown"
-    local installer="unknown"
-    local firstInstall="unknown"
-    local lastUpdate="unknown"
-    local uid="unknown"
+    version="unknown"
+    versionCode="unknown"
+    targetSdk="unknown"
+    installer="unknown"
+    firstInstall="unknown"
+    lastUpdate="unknown"
+    uid="unknown"
 
     if [[ "$(basename "$outfile")" == "base.apk" ]]; then
-        local info
         info=$(adb_shell dumpsys package "$pkg" 2>/dev/null || true)
 
         version=$(awk -F= '/versionName/{print $2;exit}' <<<"$info" | xargs || true)
@@ -61,11 +59,11 @@ if [[ -f "$outfile" ]]; then
         uid=$(awk -F= '/userId=/{print $2;exit}' <<<"$info" | xargs || true)
     fi
 
-    local installType="user"
+    installType="user"
     if [[ "$device_path" == /system/* || "$device_path" == /product/* || "$device_path" == /vendor/* || "$device_path" == /apex/* ]]; then
         installType="system"
     fi
-    local role="base"
+    role="base"
     [[ "$(basename "$outfile")" != "base.apk" ]] && role="split"
 
     LOG_PKG="$pkg" LOG_APK="$(basename "$outfile")" log INFO "✅ Metadata for $pkg → $(basename "$outfile")"
@@ -126,8 +124,8 @@ if [[ -f "$outfile" ]]; then
       '{package:$pkg,file:$file,sha256:$sha256,sha1:$sha1,md5:$md5,size:$size,perms:$perms,modified:$mtime,version:$version,versionCode:$versionCode,targetSdk:$targetSdk,installer:$installer,firstInstall:$firstInstall,lastUpdate:$lastUpdate,uid:$uid,installType:$installType,findings:$findings}' \
       >> "$JSON_REPORT.tmp"
 
-    local pulled_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-    local base_noext="${outfile%.apk}"
+    pulled_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    base_noext="${outfile%.apk}"
     {
         echo "Package: $pkg"
         echo "APK: $(basename "$outfile")"

--- a/tests/fakes/adb
+++ b/tests/fakes/adb
@@ -59,9 +59,6 @@ if [[ "${1:-}" == "-s" ]]; then
       echo "unknown"; exit 1
       ;;
 
-    get-transport-id)
-      echo "1"; exit 0
-      ;;
 
     shell)
       # Reconstruct remaining shell args

--- a/tests/fakes/hexdump
+++ b/tests/fakes/hexdump
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+args=()
+for a in "$@"; do
+  [[ "$a" == "-C" ]] && continue
+  args+=("$a")
+done
+LC_ALL=C od -An -tx1 -v "${args[@]}" | awk 'NR==1 {printf "00000000 "; for(i=1;i<=NF;i++) printf "%s ", $i; printf " |"; for(i=1;i<=NF;i++){c=strtonum("0x"$i); printf "%s",(c>=32&&c<127)?sprintf("%c",c):"."} print "|"}'

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -4,15 +4,48 @@ set -euo pipefail
 ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")"/.. && pwd)"
 export PATH="$ROOT/tests/fakes:$PATH"
 
-# Case 1: good device with trailing space in adb output
+# Repo guards
+if rg -n 'get-transport-id' -g '!tests/run.sh' -g '!scripts/archive/*' > /tmp/gtid.txt 2>&1; then
+  cat /tmp/gtid.txt
+  echo "get-transport-id found" >&2
+  exit 1
+fi
+if rg -n '\\btimeout\\b.*adb_retry' -g '!tests/run.sh' -g '!scripts/archive/*' > /tmp/tmo.txt 2>&1; then
+  cat /tmp/tmo.txt
+  echo "timeout adb_retry pattern found" >&2
+  exit 1
+fi
+
+# Load helpers
+# shellcheck disable=SC1090
+. "$ROOT/lib/core/logging.sh"
+export LOGFILE=/dev/null
+# shellcheck disable=SC1090
+. "$ROOT/lib/core/trace.sh"
+# shellcheck disable=SC1090
+. "$ROOT/lib/core/device.sh"
+# shellcheck disable=SC1090
+. "$ROOT/lib/io/apk_utils.sh"
+
+# Debug print from set_device should hex-dump the serial
+out=$(DEBUG=1 set_device 'ZY22JK89DR ' 2>&1)
+printf '%s\n' "$out" | grep -q '\[DEBUG\] DEV bytes:'
+printf '%s\n' "$out" | grep -q '5a 59 32 32 4a 4b 38 39'
+printf '%s\n' "$out" | grep -qv '0d'
+
+# Case 1: good device with trailing space
 out=$(FAKE_ADB_SCENARIO=good DEBUG=1 DH_DRY_RUN=1 "$ROOT/scripts/adb_apk_diag.sh" 2>&1)
 hex_line=$(printf '%s\n' "$out" | grep '\[DEBUG\] DEV bytes:')
-
-# The hex dump should contain the ASCII for ZY22JK89DR and no CR (0d)
 printf '%s\n' "$hex_line" | grep -q '5a 59 32 32 4a 4b 38 39[[:space:]]*44 52'
 printf '%s\n' "$hex_line" | grep -q '|ZY22JK89DR|'
 printf '%s\n' "$hex_line" | grep -qv '0d'
 printf '%s\n' "$out" | grep -q 'Artifacts in:'
+
+# Case 1b: CR in serial trimmed
+out=$(FAKE_ADB_SCENARIO=crlf DEBUG=1 DH_DRY_RUN=1 "$ROOT/scripts/adb_apk_diag.sh" 2>&1)
+hex_line=$(printf '%s\n' "$out" | grep '\[DEBUG\] DEV bytes:')
+printf '%s\n' "$hex_line" | grep -q '|ZY22JK89DR|'
+printf '%s\n' "$hex_line" | grep -qv '0d'
 
 # Case 2: DEV env var with trailing space should be trimmed
 out=$(FAKE_ADB_SCENARIO=good DEV='ZY22JK89DR ' DEBUG=1 DH_DRY_RUN=1 "$ROOT/scripts/adb_apk_diag.sh" 2>&1)
@@ -39,36 +72,120 @@ FAKE_ADB_SCENARIO=good DH_DRY_RUN=1 "$ROOT/scripts/adb_health.sh" >/dev/null
 out=$(FAKE_ADB_SCENARIO=good adb -s ZY22JK89DR shell pm list packages)
 printf '%s\n' "$out" | grep -q 'package:com.zhiliaoapp.musically'
 
-# Scan failure (simulated cmd failure)
-if FAKE_ADB_SCENARIO=list_fail adb -s ZY22JK89DR shell pm list packages >/tmp/scan_fail.log 2>&1; then
+# Scan success via wrapper (mirrors menu path)
+set_device ZY22JK89DR
+out=$(FAKE_ADB_SCENARIO=good adb_retry "$DH_SHELL_TIMEOUT" "$DH_RETRIES" "$DH_BACKOFF" pm_list -- shell pm list packages 2>&1)
+printf '%s\n' "$out" | grep -q 'package:com.zhiliaoapp.musically'
+
+# Scan failure via wrapper
+if out=$(FAKE_ADB_SCENARIO=list_fail adb_retry "$DH_SHELL_TIMEOUT" "$DH_RETRIES" "$DH_BACKOFF" pm_list -- shell pm list packages 2>&1); then
+  echo "expected wrapper list failure" >&2
+  exit 1
+fi
+printf '%s\n' "$out" | grep -q 'cmd: failure'
+
+# Noise guard: scan_apps output should not leak 'device'
+tmp=$(mktemp)
+FAKE_ADB_SCENARIO=good ROOT="$ROOT" bash -c '
+  set -euo pipefail
+  source "$ROOT/lib/core/errors.sh"
+  source "$ROOT/lib/core/logging.sh"
+  LOGFILE=/dev/null
+  source "$ROOT/lib/core/trace.sh"
+  source "$ROOT/lib/core/device.sh"
+  source "$ROOT/lib/actions/scan_apps.sh"
+  TARGET_PACKAGES=("com.zhiliaoapp.musically")
+  set_device ZY22JK89DR
+  scan_apps
+' >"$tmp" 2>&1
+grep -q 'Found: com.zhiliaoapp.musically' "$tmp"
+if grep -q '^device$' "$tmp"; then
+  echo "unexpected device noise" >&2
+  exit 1
+fi
+
+# Scan failure without debug should not print CMD
+tmp_fail=$(mktemp)
+if FAKE_ADB_SCENARIO=list_fail ROOT="$ROOT" bash -c '
+  set -euo pipefail
+  source "$ROOT/lib/core/errors.sh"
+  source "$ROOT/lib/core/logging.sh"
+  LOGFILE=/dev/null
+  source "$ROOT/lib/core/trace.sh"
+  source "$ROOT/lib/core/device.sh"
+  source "$ROOT/lib/actions/scan_apps.sh"
+  TARGET_PACKAGES=("com.zhiliaoapp.musically")
+  set_device ZY22JK89DR
+  scan_apps
+' >"$tmp_fail" 2>&1; then
   echo "expected scan failure" >&2
   exit 1
 fi
-grep -q 'cmd: failure' /tmp/scan_fail.log
+grep -q 'failed to list packages' "$tmp_fail"
+if grep -q '\[CMD\]' "$tmp_fail"; then
+  echo "CMD leaked" >&2
+  exit 1
+fi
 
-# Pull success
+# Scan failure with debug should print CMD
+tmp_fail_dbg=$(mktemp)
+if FAKE_ADB_SCENARIO=list_fail DH_DEBUG=1 ROOT="$ROOT" bash -c '
+  set -euo pipefail
+  source "$ROOT/lib/core/errors.sh"
+  source "$ROOT/lib/core/logging.sh"
+  LOGFILE=/dev/null
+  source "$ROOT/lib/core/trace.sh"
+  source "$ROOT/lib/core/device.sh"
+  source "$ROOT/lib/actions/scan_apps.sh"
+  TARGET_PACKAGES=("com.zhiliaoapp.musically")
+  set_device ZY22JK89DR
+  scan_apps
+' >"$tmp_fail_dbg" 2>&1; then
+  echo "expected scan failure" >&2
+  exit 1
+fi
+grep -q '\[CMD\]' "$tmp_fail_dbg"
+
+# Pull success via helper
 rm -rf /tmp/pull_good
-FAKE_ADB_SCENARIO=good adb -s ZY22JK89DR pull /data/app/com.zhiliaoapp.musically-1/base.apk /tmp/pull_good/base.apk >/tmp/pull_good.log
+FAKE_ADB_SCENARIO=good ROOT="$ROOT" bash -c '
+  set -euo pipefail
+  source "$ROOT/lib/core/logging.sh"
+  LOGFILE=/dev/null
+  source "$ROOT/lib/core/trace.sh"
+  source "$ROOT/lib/core/device.sh"
+  source "$ROOT/lib/io/apk_utils.sh"
+  set_device ZY22JK89DR
+  run_adb_pull_with_fallbacks /data/app/com.zhiliaoapp.musically-1/base.apk /tmp/pull_good/base.apk
+' >/tmp/pull_good.log 2>&1
 [ -s /tmp/pull_good/base.apk ]
 
-# Pull permission fallback success: direct pull fails, tmp-copy + pull succeeds
+# Pull permission fallback success
 rm -rf /tmp/pull_perm
-if FAKE_ADB_SCENARIO=pull_perm adb -s ZY22JK89DR pull /data/app/com.zhiliaoapp.musically-1/base.apk /tmp/pull_perm/base.apk >/tmp/pull_perm.log 2>&1; then
-  echo "expected direct pull failure" >&2
-  exit 1
-fi
-FAKE_ADB_SCENARIO=pull_perm adb -s ZY22JK89DR shell cp /data/app/com.zhiliaoapp.musically-1/base.apk /data/local/tmp/tmp.apk
-FAKE_ADB_SCENARIO=pull_perm adb -s ZY22JK89DR pull /data/local/tmp/tmp.apk /tmp/pull_perm/base.apk
+FAKE_ADB_SCENARIO=pull_perm ROOT="$ROOT" bash -c '
+  set -euo pipefail
+  source "$ROOT/lib/core/logging.sh"
+  LOGFILE=/dev/null
+  source "$ROOT/lib/core/trace.sh"
+  source "$ROOT/lib/core/device.sh"
+  source "$ROOT/lib/io/apk_utils.sh"
+  set_device ZY22JK89DR
+  run_adb_pull_with_fallbacks /data/app/com.zhiliaoapp.musically-1/base.apk /tmp/pull_perm/base.apk
+' >/tmp/pull_perm.log 2>&1
 [ -s /tmp/pull_perm/base.apk ]
 
-# Pull failure after fallback: everything should fail and surface "Permission denied"
+# Pull failure after fallback
 rm -rf /tmp/pull_fail
-if FAKE_ADB_SCENARIO=pull_fail adb -s ZY22JK89DR pull /data/app/com.zhiliaoapp.musically-1/base.apk /tmp/pull_fail/base.apk >/tmp/pull_fail.log 2>&1; then
-  echo "expected pull failure" >&2
-  exit 1
-fi
-FAKE_ADB_SCENARIO=pull_fail adb -s ZY22JK89DR shell cp /data/app/com.zhiliaoapp.musically-1/base.apk /data/local/tmp/tmp.apk >/tmp/pull_fail.log 2>&1 || true
-if FAKE_ADB_SCENARIO=pull_fail adb -s ZY22JK89DR pull /data/local/tmp/tmp.apk /tmp/pull_fail/base.apk >/tmp/pull_fail.log 2>&1; then
+if FAKE_ADB_SCENARIO=pull_fail ROOT="$ROOT" bash -c '
+  set -euo pipefail
+  source "$ROOT/lib/core/logging.sh"
+  LOGFILE=/dev/null
+  source "$ROOT/lib/core/trace.sh"
+  source "$ROOT/lib/core/device.sh"
+  source "$ROOT/lib/io/apk_utils.sh"
+  set_device ZY22JK89DR
+  run_adb_pull_with_fallbacks /data/app/com.zhiliaoapp.musically-1/base.apk /tmp/pull_fail/base.apk
+' >/tmp/pull_fail.log 2>&1; then
   echo "expected pull failure" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- centralize device normalization and ADB wrappers in core helpers
- streamline scan error handling and silence noisy readiness checks
- expand fake-ADB tests and add CI workflow to guard unsupported commands
- centralize debug hex dumps in `set_device` and fix shellcheck errors in metadata step

## Testing
- `shellcheck $(git ls-files '*.sh')`
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ab74194710832787d7fdfeb07c2f89