### PR TITLE
Silence PM probes and add optional log cleanup

### DIFF
--- a/config/config.sh
+++ b/config/config.sh
@@ -38,6 +38,9 @@ fi
 # Ensure base dirs exist (harmless if already present)
 mkdir -p "${RESULTS_DIR}" "${LOG_DIR}"
 
+# Automatically purge logs after run.sh exits (true/false)
+: "${CLEAR_LOGS:=false}"
+
 # ===============================
 # II. TARGET PACKAGES
 # ===============================


### PR DESCRIPTION
## Summary
- allow `run.sh` to clear accumulated logs when `CLEAR_LOGS=true` or `--clear-logs` is supplied
- rework PM helpers to avoid ERR trap noise and capture exit codes via `_pm_run_quiet`

## Testing
- `bash -n run.sh config/config.sh`
- `bash -n lib/core/device/pm.sh`
- `./tests/run.sh >/tmp/test.log && tail -n 20 /tmp/test.log` *(fails: tee found in pull path)*

------
https://chatgpt.com/codex/tasks/task_e_68abef2f1afc8327b89caf7f4cd0adcd