### PR TITLE
Fix CLEAN_LOGS variable usage

### DIFF
--- a/config/config.sh
+++ b/config/config.sh
@@ -38,8 +38,8 @@ fi
 # Ensure base dirs exist (harmless if already present)
 mkdir -p "${RESULTS_DIR}" "${LOG_DIR}"
 
-# Automatically purge logs after run.sh exits (true/false)
-: "${CLEAR_LOGS:=false}"
+# Automatically purge logs after run.sh exits (1 to enable)
+: "${CLEAN_LOGS:=0}"
 
 # ===============================
 # II. TARGET PACKAGES

--- a/lib/core/session.sh
+++ b/lib/core/session.sh
@@ -7,6 +7,7 @@ trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO" >&2' ERR
 # ---------------------------------------------------
 
 init_session() {
+    CLEAN_LOGS=${CLEAN_LOGS:-0}
     TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
     RESULTS_DIR="$SCRIPT_DIR/results"
     LOGS_DIR="$SCRIPT_DIR/logs"

--- a/run.sh
+++ b/run.sh
@@ -10,10 +10,11 @@ set -E
 trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO: $BASH_COMMAND" >&2' ERR
 
 # Optional: allow log cleanup via flag or env var
-CLEAR_LOGS="${CLEAR_LOGS:-false}"
+# Use numeric 1/0 so arithmetic comparisons work in sourced libs.
+CLEAN_LOGS=${CLEAN_LOGS:-0}
 for arg in "$@"; do
     case "$arg" in
-        --clear-logs) CLEAR_LOGS=true ;;
+        --clear-logs) CLEAN_LOGS=1 ;;
         *) echo "Usage: $0 [--clear-logs]" >&2; exit 64 ;;
     esac
 done
@@ -45,7 +46,7 @@ if declare -F validate_config >/dev/null 2>&1; then
 fi
 
 # Optionally clear logs when exiting
-if [[ "$CLEAR_LOGS" == "true" ]]; then
+if (( CLEAN_LOGS == 1 )); then
     cleanup_logs_on_exit() {
         find "$LOG_DIR" "$REPO_ROOT/config/logs" "$REPO_ROOT/scripts/logs" -type f -name '*.txt' -delete 2>/dev/null || true
     }


### PR DESCRIPTION
## Summary
- avoid unbound `CLEAN_LOGS` variable and standardize log clearing flag
- expose log clearing default in `config.sh`
- guard session initialization with default `CLEAN_LOGS`

## Testing
- `./run.sh`
- `tests/run.sh` *(fails: tee found in pull path)*

------
https://chatgpt.com/codex/tasks/task_e_68abf4311b3c83278c9de891ba9d03f8