### PR TITLE
Centralize log output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 results/
-logs/
+/log/
 *.apk
 *.zip
 *.tmp

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Bash toolkit to harvest APKs and metadata from an attached Android device via AD
 ## Usage
 
 ```bash
-./run.sh [--clean-logs]
+./run.sh
 ```
 
-Run with no arguments to open the interactive menu. Pass `--clean-logs` to remove
-existing log files before starting.
+Run with no arguments to open the interactive menu. Set `CLEAR_LOGS=true` to
+remove existing log files before starting.
 
 Typical workflow:
 
@@ -22,12 +22,12 @@ Typical workflow:
 2. Choose **Scan for target apps** to detect installed packages.
 3. Choose **Harvest** to pull APK splits and metadata for discovered apps.
 
-Artifacts and logs are written under `results/<serial>/` and `logs/` by default.
+Artifacts and logs are written under `results/<serial>/` and `log/` by default.
 
 Standalone diagnostic scripts live at `scripts/adb_apk_diag.sh` and
 `scripts/adb_health.sh`, both of which reuse the core helpers.
 
-Use `scripts/cleanup_outputs.sh` or the "Clear logs/results" menu option to
+Use `scripts/cleanup_outputs.sh` or the "Clear log/results" menu option to
 remove all previous artifacts and start fresh.
 
 ## Diagnostics
@@ -124,3 +124,16 @@ shim. Run it with:
 ```bash
 tests/run.sh
 ```
+
+## Repo Conventions
+
+- All logs are stored under `./log/`.
+- `scripts/` contains ad-hoc utilities; production code in `lib/` and `run.sh`
+  must not source from it.
+- `tests/` holds canonical tests and guards.
+
+### Environment variables
+
+- `LOG_ROOT` / `LOG_DIR` – base directory for logs (defaults to `./log`).
+- `LOG_KEEP_N` – if set to an integer, retain only that many recent log files.
+- `CLEAR_LOGS` – set to `true` to delete existing logs at startup.

--- a/config/config.sh
+++ b/config/config.sh
@@ -30,16 +30,14 @@ fi
 
 # Results & logs live at repo root by default
 : "${RESULTS_DIR:="${REPO_ROOT}/results"}"
-: "${LOG_DIR:="${REPO_ROOT}/logs"}"
+: "${LOG_ROOT:="${REPO_ROOT}/log"}"
+LOG_DIR="${LOG_DIR:-$LOG_ROOT}"
 
 # Timestamp format for log and report files (passed directly to `date`)
 : "${TIMESTAMP_FORMAT:="+%Y%m%d_%H%M%S"}"
 
 # Ensure base dirs exist (harmless if already present)
-mkdir -p "${RESULTS_DIR}" "${LOG_DIR}"
-
-# Automatically purge logs after run.sh exits (1 to enable)
-: "${CLEAN_LOGS:=0}"
+mkdir -p "${RESULTS_DIR}" "${LOG_ROOT}"
 
 # ===============================
 # II. TARGET PACKAGES
@@ -162,7 +160,7 @@ validate_config() {
 
   export ADB_BIN ADB_TIMEOUT ALLOW_MULTI_DEVICE
   export DH_SHELL_TIMEOUT DH_PULL_TIMEOUT DH_RETRIES DH_BACKOFF
-  export RESULTS_DIR LOG_DIR REPO_ROOT SCRIPT_DIR TIMESTAMP_FORMAT
+  export RESULTS_DIR LOG_ROOT LOG_DIR REPO_ROOT SCRIPT_DIR TIMESTAMP_FORMAT
   export LOG_LEVEL INCLUDE_DEVICE_PROFILE INCLUDE_ENV_METADATA
 }
 

--- a/lib/actions/harvest.sh
+++ b/lib/actions/harvest.sh
@@ -119,4 +119,5 @@ harvest() {
     finalize_report "all"
     LAST_TXT_REPORT="$TXT_REPORT"
     log SUCCESS "Harvest complete. Reports written to $RESULTS_DIR"
+    logging_rotate
 }

--- a/lib/core/session.sh
+++ b/lib/core/session.sh
@@ -7,21 +7,16 @@ trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO" >&2' ERR
 # ---------------------------------------------------
 
 init_session() {
-    CLEAN_LOGS=${CLEAN_LOGS:-0}
     TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
-    RESULTS_DIR="$SCRIPT_DIR/results"
-    LOGS_DIR="$SCRIPT_DIR/logs"
-    mkdir -p "$RESULTS_DIR" "$LOGS_DIR"
-    if (( CLEAN_LOGS == 1 )); then
-        find "$LOGS_DIR" -mindepth 1 -delete 2>/dev/null || true
-    else
-        LOG_RETENTION_DAYS=${LOG_RETENTION_DAYS:-7}
-        find "$LOGS_DIR" -type f -mtime +"$LOG_RETENTION_DAYS" -print -delete 2>/dev/null || true
-    fi
+    RESULTS_DIR="${RESULTS_DIR:-$REPO_ROOT/results}"
+    LOG_DIR="${LOG_DIR:-$REPO_ROOT/log}"
+    LOGS_DIR="$LOG_DIR"
+    mkdir -p "$RESULTS_DIR" "$LOG_DIR"
+    logging_rotate
     RESULTS_RETENTION_DAYS=${RESULTS_RETENTION_DAYS:-30}
     find "$RESULTS_DIR" -mindepth 1 -mtime +"$RESULTS_RETENTION_DAYS" -print -delete 2>/dev/null || true
 
-    LOGFILE="$LOGS_DIR/harvest_log_$TIMESTAMP.txt"
+    LOGFILE="$(_log_path harvest_log)"
     REPORT="$RESULTS_DIR/apks_report_$TIMESTAMP.csv"
     JSON_REPORT="$RESULTS_DIR/apks_report_$TIMESTAMP.json"
     TXT_REPORT="$RESULTS_DIR/apks_report_$TIMESTAMP.txt"
@@ -30,7 +25,7 @@ init_session() {
 
     DEVICE=""
     CUSTOM_PACKAGES=()
-    CUSTOM_PACKAGES_FILE="$SCRIPT_DIR/custom_packages.txt"
+    CUSTOM_PACKAGES_FILE="$REPO_ROOT/custom_packages.txt"
     [[ -f "$CUSTOM_PACKAGES_FILE" ]] && mapfile -t CUSTOM_PACKAGES < "$CUSTOM_PACKAGES_FILE"
 
     PKGS_FOUND=0
@@ -38,7 +33,7 @@ init_session() {
     LAST_TXT_REPORT=""
     DEVICE_FINGERPRINT=""
     SESSION_ID="$TIMESTAMP"
-    export DEVICE_FINGERPRINT SESSION_ID LOGFILE RESULTS_DIR LOGS_DIR REPORT JSON_REPORT TXT_REPORT
+    export DEVICE_FINGERPRINT SESSION_ID LOGFILE RESULTS_DIR LOG_DIR LOGS_DIR REPORT JSON_REPORT TXT_REPORT
 }
 
 session_metadata() {

--- a/scripts/adb_apk_diag.sh
+++ b/scripts/adb_apk_diag.sh
@@ -2,7 +2,7 @@
 # Minimal APK diagnostics using centralized helpers (Fedora/Linux)
 # - Collects pm path (raw + sanitized)
 # - Optionally pulls up to N APKs (base first), compares sizes, verifies hashes
-# - Writes summary to root logs/ and artifacts to results/<DEVICE>/
+# - Writes summary to root log/ and artifacts to results/<DEVICE>/
 set -euo pipefail
 set -E
 trap 'echo "ERROR: ${BASH_SOURCE[0]:-?}:$LINENO: $BASH_COMMAND" >&2' ERR
@@ -18,13 +18,12 @@ Examples:
 
 Notes:
 - Writes artifacts to results/<DEVICE>/manual_diag_<ts>/
-- Writes a summary to logs/adb_apk_diag_<ts>_<pkg>.txt
+  - Writes a summary to log/adb_apk_diag_<ts>_<pkg>.txt
 EOF
 }
 
 # ---- Bootstrap ---------------------------------------------------------------
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-LOG_DIR="$ROOT/logs"; mkdir -p "$LOG_DIR"
 
 # Load configs if present (idempotent)
 if [[ -d "$ROOT/config" ]]; then
@@ -33,6 +32,7 @@ if [[ -d "$ROOT/config" ]]; then
     [[ -r "$f" ]] && source "$f"
   done
 fi
+mkdir -p "$LOG_DIR"
 
 # Shared libs (ordered: logging/errors → trace → device → pm/apk utils)
 # shellcheck disable=SC1090
@@ -192,7 +192,7 @@ have_func au_scan_tiktok_family  && au_scan_tiktok_family  >"$OUT_FAM" || true
 have_func au_scan_tiktok_related && au_scan_tiktok_related >"$OUT_REL" || true
 
 # ---- Summary log -------------------------------------------------------------
-SUMMARY="$LOG_DIR/adb_apk_diag_${TS}_${PKG_ESC}.txt"
+SUMMARY="$(_log_path "adb_apk_diag_${PKG_ESC}")"
 log_file_init "$SUMMARY"
 {
   echo "package=$PKG"

--- a/scripts/archive/dev_static_check.sh
+++ b/scripts/archive/dev_static_check.sh
@@ -12,7 +12,7 @@ REPO_ROOT="$(cd "
 $(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
-LOG_DIR="$REPO_ROOT/logs"
+LOG_DIR="$REPO_ROOT/log"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/static_check_$(date +%Y%m%d_%H%M%S).txt"
 

--- a/scripts/archive/dev_wrapper_selftest.sh
+++ b/scripts/archive/dev_wrapper_selftest.sh
@@ -9,7 +9,7 @@ trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO: $BASH_COMMAND" >&2' ERR
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
-LOG_DIR="$REPO_ROOT/logs"
+LOG_DIR="$REPO_ROOT/log"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/wrappers_selftest_$(date +%Y%m%d_%H%M%S).txt"
 

--- a/scripts/archive/diag.sh
+++ b/scripts/archive/diag.sh
@@ -41,7 +41,7 @@ export LOG_LEVEL
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
-LOG_DIR="$REPO_ROOT/logs"; mkdir -p "$LOG_DIR"
+LOG_DIR="$REPO_ROOT/log"; mkdir -p "$LOG_DIR"
 
 # shellcheck disable=SC1090
 source "$REPO_ROOT/config.sh"

--- a/scripts/archive/diag_wrapper_defs.sh
+++ b/scripts/archive/diag_wrapper_defs.sh
@@ -28,7 +28,7 @@ fi
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
-LOG_DIR="$REPO_ROOT/logs"
+LOG_DIR="$REPO_ROOT/log"
 mkdir -p "$LOG_DIR"
 TS="$(date +%Y%m%d_%H%M%S)"
 TRANSCRIPT="$LOG_DIR/wrappers_diag_${TS}.txt"

--- a/scripts/archive/github-helper.sh
+++ b/scripts/archive/github-helper.sh
@@ -7,7 +7,7 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 SCRIPT_DIR="$REPO_ROOT"
 
-LOG_DIR="$REPO_ROOT/logs"
+LOG_DIR="$REPO_ROOT/log"
 mkdir -p "$LOG_DIR"
 
 # shellcheck disable=SC1090

--- a/scripts/archive/make_executable.sh
+++ b/scripts/archive/make_executable.sh
@@ -7,7 +7,7 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 SCRIPT_DIR="$REPO_ROOT"
 
-LOG_DIR="$REPO_ROOT/logs"
+LOG_DIR="$REPO_ROOT/log"
 mkdir -p "$LOG_DIR"
 
 # shellcheck disable=SC1090

--- a/scripts/migrate_logs_to_log.sh
+++ b/scripts/migrate_logs_to_log.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEST="$ROOT/log"
+mkdir -p "$DEST"
+moved=0
+for src in "$ROOT/logs" "$ROOT/config"/logs "$ROOT/scripts"/logs; do
+  if [[ -d "$src" ]]; then
+    while IFS= read -r -d '' f; do
+      mv "$f" "$DEST/"
+      ((moved++))
+    done < <(find "$src" -maxdepth 1 -type f -print0) || true
+  fi
+done
+echo "moved $moved file(s) into $DEST"

--- a/scripts/pull_apk_stream_test.sh
+++ b/scripts/pull_apk_stream_test.sh
@@ -14,11 +14,12 @@ DEV="${2:-${DEV:-}}"
 ADB_BIN="${ADB_BIN:-$(command -v adb)}"
 DH_PULL_TIMEOUT="${DH_PULL_TIMEOUT:-}"   # seconds; if set and non-zero we use `timeout`
 OUTDIR="${OUTDIR:-/tmp/dh_pull_test}"
-LOGDIR="${LOGDIR:-./logs/diag}"
-mkdir -p "$OUTDIR" "$LOGDIR"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck disable=SC1090
+source "$ROOT/lib/core/logging.sh"
+mkdir -p "$OUTDIR"
 
-TS="$(date +%Y%m%d_%H%M%S)"
-LOGFILE="$LOGDIR/pull_stream_${PKG//./_}_${TS}.log"
+LOGFILE="${LOGFILE:-$(_log_path pull_stream_${PKG//./_})}"
 
 # -----------------------------
 # Helpers
@@ -93,7 +94,8 @@ if [[ -n "$DH_PULL_TIMEOUT" && "$DH_PULL_TIMEOUT" != "0" ]]; then
   log "Using pull timeout: $DH_PULL_TIMEOUT"
 fi
 
-if maybe_timeout "pull" "$ADB_BIN" -s "$DEV" pull "$APK" "$USB_DST" 2>&1 | tee -a "$LOGFILE" ; then
+if maybe_timeout "pull" "$ADB_BIN" -s "$DEV" pull "$APK" "$USB_DST" 2>&1 \
+  | tee -a "$LOGFILE" ; then
   PULL_RC=0
   log "pull rc=0"
 else

--- a/tests/guards/no_legacy_log_paths.sh
+++ b/tests/guards/no_legacy_log_paths.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")"/../.. && pwd)"
+cd "$ROOT"
+if bad=$(git grep -nE '(logs/|config/logs|scripts/logs)' -- ':!README.md' ':!.gitignore' ':!tests/guards/no_legacy_log_paths.sh' 2>/dev/null); then
+  if [[ -n "$bad" ]]; then
+    echo "$bad"
+    echo "legacy log path reference found" >&2
+    exit 1
+  fi
+fi

--- a/tests/integration/log_write_selftest.sh
+++ b/tests/integration/log_write_selftest.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")"/../.. && pwd)"
+mkdir -p "$ROOT/log"
+source "$ROOT/lib/core/logging.sh"
+path="$(_log_path selftest)"
+log_file_init "$path"
+[[ -f "$path" ]]
+[[ ! -e "$ROOT/logs" ]]
+[[ ! -e "$ROOT/config"/logs ]]
+[[ ! -e "$ROOT/scripts"/logs ]]
+rm -f "$path"
+echo "log_write_selftest OK"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -21,6 +21,9 @@ if rg -n 'pull.+\| tee' -g '!tests/run.sh' -g '!scripts/archive/*' > /tmp/tee.tx
   exit 1
 fi
 
+"$ROOT/tests/guards/no_legacy_log_paths.sh"
+"$ROOT/tests/integration/log_write_selftest.sh"
+
 # Load helpers
 # shellcheck disable=SC1090
 . "$ROOT/lib/core/logging.sh"


### PR DESCRIPTION
## Summary
- Harden logging API with `_log_path`, stderr helpers, and rotation
- Enforce single `./log` directory with guards and migration utility
- Document log conventions and environment knobs

## Testing
- `./tests/run.sh`
- `./run.sh <<<"13"`
- `LOG_KEEP_N=3 ./run.sh <<<"13"`
- `CLEAR_LOGS=true ./run.sh <<<"13"`
- `scripts/migrate_logs_to_log.sh`


------
https://chatgpt.com/codex/tasks/task_e_68abf8b04fac8327abe50c89afa6159b