### PR TITLE
Modularize config with stable entrypoint and guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ results/
 *.apk
 *.zip
 *.tmp
+/config/local.sh

--- a/README.md
+++ b/README.md
@@ -38,7 +38,12 @@ cd scripts
 ./adb_apk_diag.sh com.zhiliaoapp.musically   # writes results/<DEVICE>/manual_diag_<ts>
 ```
 
-Configuration values are now loaded from `config/*.sh` rather than a single `config.sh`.
+## Configuration layout & overrides
+
+Configuration defaults live under `config/` and are loaded via `config/config.sh`.
+To tweak settings, create `config/local.sh` and assign variables such as
+`LOG_LEVEL=DEBUG`. New code should source `config/config.sh`; the repository
+root `config.sh` remains as a shim for legacy scripts.
 
 ## Using device helper modules
 
@@ -46,6 +51,7 @@ To write scripts that interact with a device:
 
 ```bash
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT/config/config.sh"
 source "$ROOT/lib/core/logging.sh"
 source "$ROOT/lib/core/device/env.sh"
 source "$ROOT/lib/core/device/select.sh"

--- a/config.sh
+++ b/config.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="$REPO_ROOT/config/config.sh"
+[[ -r "$TARGET" ]] || { echo "[FATAL] Missing $TARGET" >&2; exit 78; }
+# shellcheck disable=SC1090
+source "$TARGET"
+

--- a/config/_common.sh
+++ b/config/_common.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+_config_warn() { printf '[WARN][config] %s\n' "$*" >&2; }
+_is_posint()      { [[ "$1" =~ ^[0-9]+$ ]] && (( $1 > 0 )); }
+_is_nonnegint()   { [[ "$1" =~ ^[0-9]+$ ]]; }
+_is_timeout_val() { [[ "$1" == "0" || "$1" =~ ^[0-9]+([smhd])?$ ]]; }
+

--- a/config/config.sh
+++ b/config/config.sh
@@ -1,179 +1,27 @@
 #!/usr/bin/env bash
-# ---------------------------------------------------
-# config.sh
-# Global configuration for DroidHarvester
-# ---------------------------------------------------
-# Purpose:
-#   Defines global parameters for logging, outputs,
-#   hashing policies, ADB/tooling, and default packages.
-#
-# Notes:
-#   - Keep portable & ASCII-only.
-#   - Any value here can be overridden via environment.
-#   - Custom packages may be provided via external file.
-# ---------------------------------------------------
+[[ -n "${DROIDHARVESTER_CONFIG_LOADED:-}" ]] && return 0 2>/dev/null || true
+DROIDHARVESTER_CONFIG_LOADED=1
 
-# Only enable strict mode when executed directly, not when sourced.
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   set -euo pipefail
   set -E
   trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO" >&2' ERR
 fi
 
-# Determine config dir and repo root
-: "${SCRIPT_DIR:="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"}"
-: "${REPO_ROOT:="$(cd "${SCRIPT_DIR}/.." && pwd)"}"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -P "${SCRIPT_DIR}/.." && pwd)"
 
-# ===============================
-# I. OUTPUT DIRECTORIES
-# ===============================
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_common.sh"
+source "$SCRIPT_DIR/paths.sh"
+source "$SCRIPT_DIR/logging.sh"
+source "$SCRIPT_DIR/packages.sh"
+source "$SCRIPT_DIR/reporting.sh"
+source "$SCRIPT_DIR/device.sh"
+source "$SCRIPT_DIR/validate.sh"
 
-# Results & logs live at repo root by default
-: "${RESULTS_DIR:="${REPO_ROOT}/results"}"
-: "${LOG_ROOT:="${REPO_ROOT}/log"}"
-LOG_DIR="${LOG_DIR:-$LOG_ROOT}"
-
-# Timestamp format for log and report files (passed directly to `date`)
-: "${TIMESTAMP_FORMAT:="+%Y%m%d_%H%M%S"}"
-
-# Ensure base dirs exist (harmless if already present)
-mkdir -p "${RESULTS_DIR}" "${LOG_ROOT}"
-
-# ===============================
-# II. TARGET PACKAGES
-# ===============================
-
-# Default package list (social media / messaging)
-TARGET_PACKAGES=(
-  "com.zhiliaoapp.musically"    # TikTok
-  "com.facebook.katana"         # Facebook
-  "com.facebook.orca"           # Messenger
-  "com.snapchat.android"        # Snapchat
-  "com.twitter.android"         # Twitter/X
-  "com.instagram.android"       # Instagram
-  "com.whatsapp"                # WhatsApp
-)
-
-# Optional custom package list file at repo root (same level as results/)
-: "${CUSTOM_PACKAGES_FILE:="${REPO_ROOT}/custom_packages.txt"}"
-if [[ -f "$CUSTOM_PACKAGES_FILE" ]]; then
-  while IFS= read -r pkg; do
-    [[ -n "$pkg" && ! "$pkg" =~ ^[[:space:]]*# ]] && TARGET_PACKAGES+=("$pkg")
-  done < "$CUSTOM_PACKAGES_FILE"
-fi
-
-# ===============================
-# III. HASHING CONFIGURATION
-# ===============================
-
-# Hash algorithms to compute (extendable)
-# shellcheck disable=SC2034  # referenced externally
-HASH_ALGOS=("sha256" "sha1" "md5")
-
-# File size threshold (bytes) for hash computation (0 = no limit)
-: "${HASH_SIZE_LIMIT:=0}"
-
-# ===============================
-# IV. REPORTING OPTIONS
-# ===============================
-
-# Report formats to generate (txt, csv, json, html if supported)
-# shellcheck disable=SC2034  # referenced externally
-REPORT_FORMATS=("txt" "csv" "json")
-
-# Log level: INFO | DEBUG | WARN | ERROR
-: "${LOG_LEVEL:="INFO"}"
-
-# Append device profile to reports (true/false)
-: "${INCLUDE_DEVICE_PROFILE:=true}"
-
-# Append environment/system metadata (true/false)
-: "${INCLUDE_ENV_METADATA:=true}"
-
-# ===============================
-# V. ADB / DEVICE SETTINGS
-# ===============================
-
-# Preferred adb binary; override to point at Platform-Tools:
-#   ADB_BIN="$HOME/Android/platform-tools/adb" ./run.sh
-# Resolve preferred adb binary without failing when missing
-ADB_BIN="${ADB_BIN:-$(command -v adb 2>/dev/null || true)}"
-
-# Timeout for `adb wait-for-device` (seconds)
-: "${ADB_TIMEOUT:=30}"
-
-# Allow multiple devices (true/false)
-: "${ALLOW_MULTI_DEVICE:=false}"
-
-# Wrapper defaults (override via environment)
-: "${DH_SHELL_TIMEOUT:=15}"   # seconds, integer > 0
-: "${DH_PULL_TIMEOUT:=300}"   # accepts 0 (disable) or e.g. 300 / 300s
-: "${DH_RETRIES:=3}"          # integer > 0
-: "${DH_BACKOFF:=1}"          # integer > 0 (seconds)
-
-# -------------------------------
-# Validation helpers & export
-# -------------------------------
-_config_warn() {
-  # Use repo logger if loaded; otherwise stderr
-  if declare -F log >/dev/null 2>&1; then
-    LOG_COMP="config" log WARN "$*"
-  else
-    printf '[WARN][config] %s\n' "$*" >&2
-  fi
-}
-
-_is_posint() { [[ "$1" =~ ^[0-9]+$ ]] && (( $1 > 0 )); }
-_is_nonnegint() { [[ "$1" =~ ^[0-9]+$ ]]; }
-_is_timeout_val() {
-  # 0 OR integer seconds OR integer with s/m/h/d suffix
-  [[ "$1" == "0" || "$1" =~ ^[0-9]+([smhd])?$ ]]
-}
-
-validate_config() {
-  local v
-  # DH_SHELL_TIMEOUT must be > 0 integer
-  v="${DH_SHELL_TIMEOUT}"
-  if ! _is_posint "$v"; then
-    _config_warn "DH_SHELL_TIMEOUT invalid ($v); defaulting to 15"
-    DH_SHELL_TIMEOUT=15
-  fi
-
-  # DH_PULL_TIMEOUT: allow 0 or suffixed values
-  v="${DH_PULL_TIMEOUT}"
-  if ! _is_timeout_val "$v"; then
-    _config_warn "DH_PULL_TIMEOUT invalid ($v); defaulting to 300"
-    DH_PULL_TIMEOUT=300
-  fi
-
-  # DH_RETRIES, DH_BACKOFF must be > 0 integer
-  v="${DH_RETRIES}"
-  if ! _is_posint "$v"; then
-    _config_warn "DH_RETRIES invalid ($v); defaulting to 3"
-    DH_RETRIES=3
-  fi
-  v="${DH_BACKOFF}"
-  if ! _is_posint "$v"; then
-    _config_warn "DH_BACKOFF invalid ($v); defaulting to 1"
-    DH_BACKOFF=1
-  fi
-
-  export ADB_BIN ADB_TIMEOUT ALLOW_MULTI_DEVICE
-  export DH_SHELL_TIMEOUT DH_PULL_TIMEOUT DH_RETRIES DH_BACKOFF
-  export RESULTS_DIR LOG_ROOT LOG_DIR REPO_ROOT SCRIPT_DIR TIMESTAMP_FORMAT
-  export LOG_LEVEL INCLUDE_DEVICE_PROFILE INCLUDE_ENV_METADATA
-}
+# Optional local overrides
+[[ -r "$SCRIPT_DIR/local.sh" ]] && source "$SCRIPT_DIR/local.sh"
 
 validate_config
 
-# ===============================
-# VI. ANALYST NOTES
-# ===============================
-# Override examples:
-#   LOG_LEVEL=DEBUG ./run.sh
-#   REPORT_FORMATS=("csv") ./run.sh
-#   ADB_BIN="$HOME/Android/platform-tools/adb" ./run.sh
-#   DH_PULL_TIMEOUT=0 ./run.sh               # disable transfer timeout
-#   DH_PULL_TIMEOUT=600s ./run.sh            # 10 minutes
-#   CUSTOM_PACKAGES_FILE=/path/to/extra.txt ./run.sh
-# ---------------------------------------------------

--- a/config/device.sh
+++ b/config/device.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+ADB_BIN_DEFAULT="$(command -v adb 2>/dev/null || true)"
+if [[ -z "$ADB_BIN_DEFAULT" && -n "${ANDROID_HOME:-}" && -x "${ANDROID_HOME}/platform-tools/adb" ]]; then
+  ADB_BIN_DEFAULT="${ANDROID_HOME}/platform-tools/adb"
+fi
+: "${ADB_BIN:="$ADB_BIN_DEFAULT"}"
+: "${ADB_TIMEOUT:=30}"
+: "${ALLOW_MULTI_DEVICE:=false}"
+: "${DH_USER_ID:=}"
+: "${DH_SHELL_TIMEOUT:=15}"
+: "${DH_PULL_TIMEOUT:=300}"
+: "${DH_RETRIES:=3}"
+: "${DH_BACKOFF:=1}"
+

--- a/config/local.sh
+++ b/config/local.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Local overrides for DroidHarvester configuration.
+# Copy variables here to customize settings. All lines are optional.
+
+# LOG_LEVEL=DEBUG
+# DH_SHELL_TIMEOUT=30
+# DH_PULL_TIMEOUT=0
+

--- a/config/logging.sh
+++ b/config/logging.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+: "${LOG_KEEP_N:=}"
+: "${CLEAR_LOGS:=false}"
+

--- a/config/packages.sh
+++ b/config/packages.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+TARGET_PACKAGES=(
+  "com.zhiliaoapp.musically"    # TikTok
+  "com.facebook.katana"         # Facebook
+  "com.facebook.orca"           # Messenger
+  "com.snapchat.android"        # Snapchat
+  "com.twitter.android"         # Twitter/X
+  "com.instagram.android"       # Instagram
+  "com.whatsapp"                # WhatsApp
+)
+
+: "${CUSTOM_PACKAGES_FILE:="$REPO_ROOT/custom_packages.txt"}"
+if [[ -f "$CUSTOM_PACKAGES_FILE" ]]; then
+  while IFS= read -r pkg; do
+    [[ -n "$pkg" && ! "$pkg" =~ ^[[:space:]]*# ]] && TARGET_PACKAGES+=("$pkg")
+  done < "$CUSTOM_PACKAGES_FILE"
+fi
+

--- a/config/paths.sh
+++ b/config/paths.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+: "${RESULTS_DIR:="$REPO_ROOT/results"}"
+: "${LOG_ROOT:="$REPO_ROOT/log"}"
+: "${LOG_DIR:="$LOG_ROOT"}"
+: "${TIMESTAMP_FORMAT:="+%Y%m%d_%H%M%S"}"
+mkdir -p "$RESULTS_DIR" "$LOG_ROOT"
+

--- a/config/reporting.sh
+++ b/config/reporting.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+HASH_ALGOS=("sha256" "sha1" "md5")
+: "${HASH_SIZE_LIMIT:=0}"
+
+REPORT_FORMATS=("txt" "csv" "json")
+: "${LOG_LEVEL:="INFO"}"
+: "${INCLUDE_DEVICE_PROFILE:=true}"
+: "${INCLUDE_ENV_METADATA:=true}"
+

--- a/config/validate.sh
+++ b/config/validate.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+validate_config() {
+  local v
+
+  v="${DH_SHELL_TIMEOUT}"
+  if ! _is_posint "$v"; then
+    _config_warn "DH_SHELL_TIMEOUT invalid ($v); defaulting to 15"
+    DH_SHELL_TIMEOUT=15
+  fi
+
+  v="${DH_PULL_TIMEOUT}"
+  if ! _is_timeout_val "$v"; then
+    _config_warn "DH_PULL_TIMEOUT invalid ($v); defaulting to 300"
+    DH_PULL_TIMEOUT=300
+  fi
+
+  v="${DH_RETRIES}"
+  if ! _is_posint "$v"; then
+    _config_warn "DH_RETRIES invalid ($v); defaulting to 3"
+    DH_RETRIES=3
+  fi
+
+  v="${DH_BACKOFF}"
+  if ! _is_posint "$v"; then
+    _config_warn "DH_BACKOFF invalid ($v); defaulting to 1"
+    DH_BACKOFF=1
+  fi
+
+  if [[ -z "${ADB_BIN:-}" || ! -x "$ADB_BIN" ]]; then
+    _config_warn "ADB_BIN not set or not executable ($ADB_BIN)"
+  fi
+
+  export REPO_ROOT SCRIPT_DIR RESULTS_DIR LOG_ROOT LOG_DIR TIMESTAMP_FORMAT
+  export LOG_KEEP_N CLEAR_LOGS
+  export ADB_BIN ADB_TIMEOUT ALLOW_MULTI_DEVICE DH_USER_ID
+  export DH_SHELL_TIMEOUT DH_PULL_TIMEOUT DH_RETRIES DH_BACKOFF
+  export LOG_LEVEL INCLUDE_DEVICE_PROFILE INCLUDE_ENV_METADATA
+}
+

--- a/lib/core/logging.sh
+++ b/lib/core/logging.sh
@@ -15,11 +15,19 @@ NC="\033[0m"
 
 : "${LOG_LEVEL:=INFO}"
 : "${REPO_ROOT:="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"}"
-: "${SCRIPT_DIR:="$REPO_ROOT"}"
-: "${LOG_DIR:="$REPO_ROOT/log"}"
-LOG_ROOT="${LOG_ROOT:-$LOG_DIR}"
-LOGS_DIR="$LOG_DIR"
-mkdir -p "$LOG_DIR"
+: "${LOG_ROOT:="$REPO_ROOT/log"}"
+: "${LOG_DIR:="${LOG_ROOT}"}"
+
+logging_init() {
+    mkdir -p "$LOG_DIR"
+    if [[ "${CLEAR_LOGS:-false}" == true ]]; then
+        rm -f "$LOG_DIR"/*.txt 2>/dev/null || true
+    fi
+    logging_rotate
+    if [[ -z "${LOGFILE:-}" ]]; then
+        LOGFILE="$(_log_path harvest_log)"
+    fi
+}
 
 _log_path() {
     local prefix="$1"
@@ -46,8 +54,9 @@ logging_rotate() {
     done
 }
 
-if [[ -z "${LOGFILE:-}" ]]; then
-    LOGFILE="$(_log_path harvest_log)"
+if [[ -z "${DROIDHARVESTER_LOGGING_INITIALIZED:-}" ]]; then
+    logging_init
+    DROIDHARVESTER_LOGGING_INITIALIZED=1
 fi
 
 # Initialize logging to a specific file

--- a/run.sh
+++ b/run.sh
@@ -17,27 +17,17 @@ DEVICE=""
 LOG_LEVEL=${LOG_LEVEL:-INFO}
 DH_DEBUG=${DH_DEBUG:-0}
 
-# Load error/logging helpers early
+# Load config first so logging picks up overrides
 # shellcheck disable=SC1090
-source "$REPO_ROOT/lib/core/errors.sh"
+source "$REPO_ROOT/config/config.sh"
+
+# Logging then errors depend on config
 # shellcheck disable=SC1090
 source "$REPO_ROOT/lib/core/logging.sh"
+# shellcheck disable=SC1090
+source "$REPO_ROOT/lib/core/errors.sh"
 
 export LOG_LEVEL DH_DEBUG
-
-# Load all config snippets from config/*.sh
-for f in "$REPO_ROOT"/config/*.sh; do
-    # shellcheck disable=SC1090
-    [[ -r "$f" ]] && source "$f"
-done
-# Validate if helper exists
-if declare -F validate_config >/dev/null 2>&1; then
-    validate_config
-fi
-
-if [[ "${CLEAR_LOGS:-false}" == "true" ]]; then
-    find "$LOG_ROOT" -type f -name '*.txt' -delete 2>/dev/null || true
-fi
 
 # Core + IO + menu libs
 # shellcheck disable=SC1090

--- a/scripts/adb_apk_diag.sh
+++ b/scripts/adb_apk_diag.sh
@@ -25,14 +25,9 @@ EOF
 # ---- Bootstrap ---------------------------------------------------------------
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# Load configs if present (idempotent)
-if [[ -d "$ROOT/config" ]]; then
-  for f in "$ROOT"/config/*.sh; do
-    # shellcheck disable=SC1090
-    [[ -r "$f" ]] && source "$f"
-  done
-fi
-mkdir -p "$LOG_DIR"
+# Load config first so helpers honor overrides
+# shellcheck disable=SC1090
+source "$ROOT/config/config.sh"
 
 # Shared libs (ordered: logging/errors → trace → device → pm/apk utils)
 # shellcheck disable=SC1090
@@ -51,6 +46,8 @@ source "$ROOT/lib/core/device/wrappers.sh"
 source "$ROOT/lib/core/device/pm.sh"
 # shellcheck disable=SC1090
 source "$ROOT/lib/io/apk_utils.sh"
+
+log_file_init "$(_log_path adb_apk_diag)"
 
 # ---- CLI ---------------------------------------------------------------------
 PULL=0

--- a/scripts/adb_health.sh
+++ b/scripts/adb_health.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# Load config so logging and device helpers see overrides
+# shellcheck disable=SC1090
+source "$ROOT/config/config.sh"
+
 # Shared helpers
 # shellcheck disable=SC1090
 source "$ROOT/lib/core/logging.sh"
@@ -18,6 +22,8 @@ source "$ROOT/lib/core/device/select.sh"
 source "$ROOT/lib/core/device/wrappers.sh"
 # shellcheck disable=SC1090
 source "$ROOT/lib/core/device/health.sh"
+
+log_file_init "$(_log_path adb_health)"
 
 SERIAL="$(device_pick_or_fail "${1:-}")"
 set_device "$SERIAL"

--- a/scripts/archive/diag.sh
+++ b/scripts/archive/diag.sh
@@ -44,7 +44,7 @@ cd "$REPO_ROOT"
 LOG_DIR="$REPO_ROOT/log"; mkdir -p "$LOG_DIR"
 
 # shellcheck disable=SC1090
-source "$REPO_ROOT/config.sh"
+source "$REPO_ROOT/config/config.sh"
 # shellcheck disable=SC1090
 for m in core/logging core/errors core/deps core/device core/trace io/report; do
   source "$REPO_ROOT/lib/$m.sh"

--- a/scripts/archive/diag_wrapper_defs.sh
+++ b/scripts/archive/diag_wrapper_defs.sh
@@ -62,7 +62,7 @@ print_set "Before sourcing libs" || true
 
 # B) Source config and likely providers of these wrappers
 # shellcheck disable=SC1090
-source "$REPO_ROOT/config.sh" || true
+source "$REPO_ROOT/config/config.sh" || true
 
 # shellcheck disable=SC1090
 source "$REPO_ROOT/lib/core/logging.sh"  || true

--- a/scripts/archive/github-helper.sh
+++ b/scripts/archive/github-helper.sh
@@ -11,7 +11,7 @@ LOG_DIR="$REPO_ROOT/log"
 mkdir -p "$LOG_DIR"
 
 # shellcheck disable=SC1090
-source "$REPO_ROOT/config.sh"
+source "$REPO_ROOT/config/config.sh"
 for m in core/logging core/errors core/deps; do
   # shellcheck disable=SC1090
   source "$REPO_ROOT/lib/$m.sh"

--- a/scripts/archive/make_executable.sh
+++ b/scripts/archive/make_executable.sh
@@ -11,7 +11,7 @@ LOG_DIR="$REPO_ROOT/log"
 mkdir -p "$LOG_DIR"
 
 # shellcheck disable=SC1090
-source "$REPO_ROOT/config.sh"
+source "$REPO_ROOT/config/config.sh"
 for m in core/logging core/errors; do
   # shellcheck disable=SC1090
   source "$REPO_ROOT/lib/$m.sh"

--- a/scripts/cleanup_outputs.sh
+++ b/scripts/cleanup_outputs.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-for f in "$ROOT"/config/*.sh; do
-  # shellcheck disable=SC1090
-  [[ -r "$f" ]] && source "$f"
-done
+
+# Load config and logging for consistent paths
+# shellcheck disable=SC1090
+source "$ROOT/config/config.sh"
 # shellcheck disable=SC1090
 source "$ROOT/lib/core/logging.sh"
 # shellcheck disable=SC1090
 source "$ROOT/lib/actions/cleanup.sh"
+
+log_file_init "$(_log_path cleanup)"
 cleanup_all_artifacts

--- a/steps/generate_apk_list.sh
+++ b/steps/generate_apk_list.sh
@@ -13,7 +13,7 @@ fi
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck disable=SC1090
-source "$REPO_ROOT/config.sh"
+source "$REPO_ROOT/config/config.sh"
 # shellcheck disable=SC1090
 for m in core/logging core/errors core/trace core/device io/apk_utils; do
   source "$REPO_ROOT/lib/$m.sh"

--- a/steps/generate_apk_metadata.sh
+++ b/steps/generate_apk_metadata.sh
@@ -15,7 +15,7 @@ fi
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck disable=SC1090
-source "$REPO_ROOT/config.sh"
+source "$REPO_ROOT/config/config.sh"
 # shellcheck disable=SC1090
 for m in core/logging core/errors core/trace core/device io/report; do
   source "$REPO_ROOT/lib/$m.sh"

--- a/tests/guards/no_root_config_imports.sh
+++ b/tests/guards/no_root_config_imports.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+if git grep -n 'source "$REPO_ROOT/config.sh"' -- 'lib/**' 'steps/**' 'scripts/**' 'run.sh' >/tmp/root_config.txt; then
+  cat /tmp/root_config.txt
+  echo "Disallowed import of root config.sh detected" >&2
+  exit 1
+fi
+

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -21,6 +21,7 @@ if rg -n 'pull.+\| tee' -g '!tests/run.sh' -g '!scripts/archive/*' > /tmp/tee.tx
   exit 1
 fi
 
+"$ROOT/tests/guards/no_root_config_imports.sh"
 "$ROOT/tests/guards/no_legacy_log_paths.sh"
 "$ROOT/tests/integration/log_write_selftest.sh"
 


### PR DESCRIPTION
## Summary
- Split configuration into modules for paths, logging, packages, reporting, device, and validation
- Added `config/config.sh` entrypoint with idempotent guard, local overrides, and validation
- Introduced guard test preventing legacy `config.sh` imports and updated docs
- Ensured logging initialization honors config by loading config before logging in core scripts

## Testing
- `bash -n $(git ls-files "config/*.sh")`
- `tests/guards/no_root_config_imports.sh`
- `source config/config.sh && env | grep -E '^(REPO_ROOT|RESULTS_DIR|LOG_ROOT|LOG_DIR|ADB_BIN|DH_SHELL_TIMEOUT)='`
- `source ./config.sh`
- `bash -n steps/generate_apk_list.sh steps/generate_apk_metadata.sh`
- `./scripts/adb_health.sh >/tmp/adb_health.log 2>&1 || true`
- `tail -n 5 /tmp/adb_health.log`
- `unset DROIDHARVESTER_CONFIG_LOADED; echo 'LOG_LEVEL=DEBUG' > config/local.sh; source config/config.sh; env | grep '^LOG_LEVEL=DEBUG'; rm config/local.sh`
- `tests/integration/log_write_selftest.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ac02f62fd48327898de0e310651c22