### PR TITLE
feat: high-contrast theme, menu polish, and quick-pull finalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Typical workflow:
 
 Artifacts and logs are written under `results/<serial>/` and `logs/` by default.
 
+After `[4] Quick APK Harvest`, friendly copies are normalized under
+`results/<serial>/quick_pull_results/`. Each app gets a human-friendly
+directory and versioned filename, and a run-level `manifest.csv` lists
+every base and split APK. Package→name mappings live in
+`config/packages.sh` and can be customized.
+
 Standalone diagnostic scripts live at `scripts/adb_apk_diag.sh` and
 `scripts/adb_health.sh`, both of which reuse the core helpers.
 
@@ -121,6 +127,15 @@ The behaviour of pull helpers can be tuned with environment variables:
 | `DH_PULL_TIMEOUT` | Seconds for adb pull (default 60). |
 | `DH_RETRIES` | Retry count for ADB commands (default 3). |
 | `DH_BACKOFF` | Seconds between retries (default 1). |
+
+## UI theme configuration
+
+The interactive menus use a high-contrast palette tuned for dark terminals. Use the following knobs to adjust or disable styling:
+
+- `NO_COLOR=1` – disable all colors.
+- `DH_THEME=mono` – keep layout but drop colors.
+- `DH_THEME=dark-hi` – explicit high-contrast theme (default).
+- `DH_NO_UNICODE=1` – use plain ASCII borders instead of Unicode.
 
 ## Tests
 

--- a/lib/menu/header.sh
+++ b/lib/menu/header.sh
@@ -11,26 +11,30 @@ source "$REPO_ROOT/lib/ui/colors.sh"
 
 draw_menu_header() {
     local title="$1"
-    local device_arg="${2-__unset__}"
-    local report_arg="${3-__unset__}"
+    local device_arg="${2-}"
+    local report_arg="${3-}"
+    local line
+    line=$(ui_line "$UI_H2")
     echo
-    echo "${CYAN}============================================================${NC}"
-    printf " ${CYAN}%-58s${NC}\n" "DROIDHARVESTER // ANALYST CONTROL INTERFACE"
-    echo "${CYAN}------------------------------------------------------------${NC}"
-    printf " ${CYAN}%-58s${NC}\n" "SESSION : $(date '+%Y-%m-%d %H:%M:%S')"
-    printf " ${CYAN}%-58s${NC}\n" "MODULE  : $title"
-    if [[ "$device_arg" != "__unset__" ]]; then
-        printf " ${CYAN}%-58s${NC}\n" "DEVICE  : ${device_arg:-Not selected}"
+    echo "${CYAN}${line}${NC}"
+    printf " ${WHITE}%s${NC}\n" "DROIDHARVESTER // ANALYST CONTROL INTERFACE"
+    echo "${CYAN}${line}${NC}"
+    printf " ${CYAN}SESSION${NC} : ${WHITE}%s${NC}\n" "$(date '+%Y-%m-%d %H:%M:%S')"
+    printf " ${CYAN}MODULE ${NC} : ${WHITE}%s${NC}\n" "$title"
+    if [[ -n "$device_arg" ]]; then
+        printf " ${CYAN}DEVICE ${NC} : ${WHITE}%s${NC}\n" "${device_arg:-Not selected}"
     fi
-    if [[ "$report_arg" != "__unset__" ]]; then
-        printf " ${CYAN}%-58s${NC}\n" "REPORT  : ${report_arg:-None}"
+    if [[ -n "$report_arg" ]]; then
+        printf " ${CYAN}REPORT ${NC} : ${WHITE}%s${NC}\n" "${report_arg:-None}"
     fi
-    echo "${CYAN}============================================================${NC}"
+    echo "${CYAN}${line}${NC}"
 }
 
 draw_menu_footer() {
     local status="${1:-Awaiting analyst command...}"
-    echo "${CYAN}------------------------------------------------------------${NC}"
-    printf " ${CYAN}%-58s${NC}\n" "STATUS : $status"
-    echo "${CYAN}============================================================${NC}"
+    local line
+    line=$(ui_line "$UI_H1")
+    echo "${CYAN}${line}${NC}"
+    printf " ${CYAN}STATUS${NC} : ${WHITE}%s${NC}\n" "$status"
+    echo "${CYAN}$(ui_line "$UI_H2")${NC}"
 }

--- a/lib/menu/main_menu.sh
+++ b/lib/menu/main_menu.sh
@@ -18,30 +18,24 @@ render_main_menu() {
     fi
 
     draw_menu_header "$title" "$device" "$last_report"
-    echo " Harvested   : found ${PKGS_FOUND:-0} pulled ${PKGS_PULLED:-0}"
-    echo " Targets     : ${#TARGET_PACKAGES[@]} default / ${custom_count} custom"
-
+    printf " ${WHITE}Harvested${NC}: found ${YELLOW}%s${NC} / pulled ${YELLOW}%s${NC} | Targets: ${YELLOW}%s${NC} default / ${YELLOW}%s${NC} custom | Latest: %s\n" \
+        "${PKGS_FOUND:-0}" "${PKGS_PULLED:-0}" "${#TARGET_PACKAGES[@]}" "$custom_count" "${QUICK_PULL_DIR:-n/a}"
     echo
-    local options=(
-        "Choose device"
-        "Scan for target apps"
-        "Add custom package"
-        "Quick APK Harvest"
-        "Harvest APKs + metadata"
-        "View last report"
-        "List ALL installed apps"
-        "Search installed apps"
-        "Device capability report"
-        "Export report bundle"
-        "Resume last session"
-        "Clean up partial run"
+    show_menu \
+        "Choose device" \
+        "Scan for target apps" \
+        "" \
+        "Add custom package" \
+        "Quick APK Harvest" \
+        "Show latest quick-pull" \
+        "Harvest APKs + metadata" \
+        "" \
+        "View last report" \
+        "List ALL installed apps" \
+        "Search installed apps" \
+        "Device capability report" \
+        "Export report bundle" \
+        "Resume last session" \
+        "Clean up partial run" \
         "Clear logs/results"
-    )
-    local i=1
-    for opt in "${options[@]}"; do
-        printf "  ${BLUE}[%2d]${NC} %s\n" "$i" "$opt"
-        ((i++))
-    done
-    printf "  ${BLUE}[ 0]${NC} Exit\n"
-    echo "${CYAN}------------------------------------------------------------${NC}"
 }

--- a/lib/menu/menu_util.sh
+++ b/lib/menu/menu_util.sh
@@ -21,10 +21,15 @@ show_menu() {
     local i=1
     echo
     for option in "$@"; do
-        printf "  ${BLUE}[%2d]${NC} %s\n" "$i" "$option"
+        if [[ -z "$option" ]]; then
+            echo
+            continue
+        fi
+        printf "  ${YELLOW}[%2d]${NC} ${WHITE}%s${NC}\n" "$i" "$option"
         ((i++))
     done
-    echo "${CYAN}------------------------------------------------------------${NC}"
+    printf "  ${YELLOW}[ 0]${NC} ${GRAY}Exit${NC}\n"
+    echo "${CYAN}$(ui_line "$UI_H1")${NC}"
 }
 
 # ---------------------------------------------------
@@ -74,4 +79,3 @@ confirm() {
         *)     return 1 ;;
     esac
 }
-

--- a/lib/ui/colors.sh
+++ b/lib/ui/colors.sh
@@ -1,27 +1,54 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034
+# ---------------------------------------------------
+# lib/ui/colors.sh - High contrast palette & helpers
+# ---------------------------------------------------
 set -euo pipefail
 set -E
 trap 'echo "ERROR: ${BASH_SOURCE[0]}:$LINENO" >&2' ERR
-# ---------------------------------------------------
-# lib/colors.sh
-# Centralized color/format definitions
-# ---------------------------------------------------
 
-if tput setaf 1 >/dev/null 2>&1; then
-    # Use tput for portability
-    RED=$(tput setaf 1)
-    GREEN=$(tput setaf 2)
-    YELLOW=$(tput setaf 3)
-    BLUE=$(tput setaf 4)
-    CYAN=$(tput setaf 6)
-    NC=$(tput sgr0)  # reset
+: "${DH_THEME:=dark-hi}"
+
+# Disable colors for NO_COLOR=1 or DH_THEME=mono
+if [[ "${NO_COLOR-}" == "1" || "$DH_THEME" == "mono" ]]; then
+    RED=""; GREEN=""; YELLOW=""; CYAN=""; WHITE=""; GRAY=""; BLUE=""; NC=""
 else
-    # Fallback ANSI escape sequences
-    RED="\033[0;31m"
-    GREEN="\033[0;32m"
-    YELLOW="\033[1;33m"
-    BLUE="\033[0;34m"
-    CYAN="\033[0;36m"
-    NC="\033[0m"
+    if tput setaf 1 >/dev/null 2>&1; then
+        RED=$(tput setaf 9)
+        GREEN=$(tput setaf 10)
+        YELLOW=$(tput setaf 11)
+        CYAN=$(tput setaf 14)
+        WHITE=$(tput setaf 15)
+        GRAY=$(tput setaf 8)
+        BLUE="$CYAN"
+        NC=$(tput sgr0)
+    else
+        RED="\033[1;31m"
+        GREEN="\033[1;32m"
+        YELLOW="\033[1;33m"
+        CYAN="\033[1;36m"
+        WHITE="\033[1;37m"
+        GRAY="\033[0;90m"
+        BLUE="$CYAN"
+        NC="\033[0m"
+    fi
 fi
+
+# Line characters (unicode default with ASCII fallback)
+if [[ "${DH_NO_UNICODE:-0}" == "1" ]]; then
+    UI_H1="-"
+    UI_H2="="
+else
+    UI_H1="─"
+    UI_H2="═"
+fi
+
+# Draw a horizontal line of given char and width (default 70)
+ui_line() {
+    local char="${1:-$UI_H1}" width="${2:-70}"
+    local out=""
+    for ((i=0; i<width; i++)); do
+        out+="$char"
+    done
+    printf '%s' "$out"
+}

--- a/run.sh
+++ b/run.sh
@@ -86,7 +86,7 @@ while true; do
   [[ -n "$LAST_TXT_REPORT" ]] && header_report="$(basename "$LAST_TXT_REPORT")"
 
   render_main_menu "DroidHarvester Main Menu" "$DEVICE" "$header_report"
-  choice="$(read_choice_range 0 13)"
+  choice="$(read_choice_range 0 14)"
   echo
 
   case "$choice" in
@@ -103,6 +103,12 @@ while true; do
         if [[ -x "$REPO_ROOT/scripts/finalize_quickpull.sh" ]]; then
           echo "[INFO] Finalizing quick pull (friendly names + manifest)..."
           "$REPO_ROOT/scripts/finalize_quickpull.sh" || true
+          qdir="$RESULTS_DIR/$DEV/quick_pull_results"
+          if [[ -f "$qdir/manifest.csv" ]]; then
+            QUICK_PULL_DIR="$(basename "$qdir")"
+            PKGS_FOUND=$(tail -n +2 "$qdir/manifest.csv" | cut -d, -f3 | sort -u | wc -l | tr -d ' ')
+            PKGS_PULLED=$(( $(wc -l < "$qdir/manifest.csv" | tr -d ' ') - 1 ))
+          fi
         fi
       else
         LOG_COMP="core" log WARN "scripts/grab_apks.sh missing or not executable."
@@ -111,18 +117,27 @@ while true; do
       ;;
 
     5)
+      # Show latest quick-pull
+      if [[ -x "$REPO_ROOT/scripts/show_latest_quickpull.sh" ]]; then
+        "$REPO_ROOT/scripts/show_latest_quickpull.sh" || true
+      else
+        echo "[ERR] scripts/show_latest_quickpull.sh missing or not executable." >&2
+      fi
+      ;;
+
+    6)
       # Full pipeline (metadata, reports)
       ensure_device_selected
       harvest
       ;;
-    6) view_report ;;
-    7) list_installed_apps ;;
-    8) search_installed_apps ;;
-    9) capability_report ;;
-    10) export_report ;;
-    11) resume_last_session ;;
-    12) cleanup_partial_run ;;
-    13) cleanup_all_artifacts ;;
+    7) view_report ;;
+    8) list_installed_apps ;;
+    9) search_installed_apps ;;
+    10) capability_report ;;
+    11) export_report ;;
+    12) resume_last_session ;;
+    13) cleanup_partial_run ;;
+    14) cleanup_all_artifacts ;;
 
     0)
       LOG_COMP="core" log INFO "Exiting DroidHarvester."

--- a/scripts/show_latest_quickpull.sh
+++ b/scripts/show_latest_quickpull.sh
@@ -15,20 +15,12 @@ try_source() { [[ -r "$1" ]] && source "$1" >/dev/null 2>&1 || true; } # shellch
 try_source "$REPO_ROOT/config/config.sh"
 try_source "$REPO_ROOT/config/paths.sh"
 
-# --- Candidate log dirs (prefer configured LOG_ROOT if present) ---
-CAND_LOG_DIRS=()
-[[ -n "${LOG_ROOT:-}" ]] && CAND_LOG_DIRS+=("$LOG_ROOT")
-CAND_LOG_DIRS+=("$REPO_ROOT/log" "$REPO_ROOT/logs")
-
+# --- Locate latest quick pull log under configured LOG_DIR ---
 pick_newest_log() {
-  local d
-  for d in "${CAND_LOG_DIRS[@]}"; do
-    [[ -d "$d" ]] || continue
-    compgen -G "$d/apk_grab_*.txt" >/dev/null || continue
-    ls -1t "$d"/apk_grab_*.txt | head -1
-    return 0
-  done
-  return 1
+  local d="${LOG_DIR:-$REPO_ROOT/logs}"
+  [[ -d "$d" ]] || return 1
+  compgen -G "$d/apk_grab_*.txt" >/dev/null || return 1
+  ls -1t "$d"/apk_grab_*.txt | head -1
 }
 
 # --- Determine OUT (quick_pull folder) ---

--- a/steps/finalize_quickpull.sh
+++ b/steps/finalize_quickpull.sh
@@ -150,7 +150,7 @@ for pkg_dir in "$SRC_ROOT"/*; do
     dst="$dst_app_dir/$out_file"
     dst="$(unique_dest "$dst")"
     cp -f "$src_apk" "$dst"
-    ((changed++))
+    ((changed+=1))
 
     bytes="$(stat -c %s "$dst" 2>/dev/null || wc -c < "$dst")"
     hash="$(sha256_host "$dst")"

--- a/tests/integration/finalize_quickpull_test.sh
+++ b/tests/integration/finalize_quickpull_test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")"/../.. && pwd)"
+export REPO_ROOT="$ROOT"
+export RESULTS_DIR="$ROOT/results_test"
+rm -rf "$RESULTS_DIR"
+mkdir -p "$RESULTS_DIR"
+source "$ROOT/config/config.sh" >/dev/null 2>&1
+source "$ROOT/config/packages.sh" >/dev/null 2>&1
+DEV="FAKE123"
+RUN_DIR="$RESULTS_DIR/$DEV/quick_pull_20240101_000000"
+for pkg in "${!FRIENDLY_DIR_MAP[@]}"; do
+  mkdir -p "$RUN_DIR/$pkg/pulled"
+  echo "$pkg" > "$RUN_DIR/$pkg/pulled/base.apk"
+done
+# add a split apk for one package to verify manifest handles splits
+mkdir -p "$RUN_DIR/com.facebook.katana/pulled"
+echo split > "$RUN_DIR/com.facebook.katana/pulled/split_config.en.apk"
+
+"$ROOT/steps/finalize_quickpull.sh" >/tmp/finalize.log
+
+MANIFEST="$RESULTS_DIR/$DEV/quick_pull_results/manifest.csv"
+[ -f "$MANIFEST" ]
+grep -q 'split_config.en.apk' "$MANIFEST"
+
+for pkg in "${!FRIENDLY_DIR_MAP[@]}"; do
+  dir="${FRIENDLY_DIR_MAP[$pkg]}"
+  file="${FRIENDLY_FILE_MAP[$pkg]}.apk"
+  [ -f "$RESULTS_DIR/$DEV/quick_pull_results/$dir/$file" ]
+done
+
+rm -rf "$RESULTS_DIR"
+echo "finalize_quickpull_test OK"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -24,6 +24,7 @@ fi
 "$ROOT/tests/guards/no_root_config_imports.sh"
 "$ROOT/tests/guards/no_legacy_log_paths.sh"
 "$ROOT/tests/integration/log_write_selftest.sh"
+"$ROOT/tests/integration/finalize_quickpull_test.sh"
 
 # Load helpers
 # shellcheck disable=SC1090


### PR DESCRIPTION
## Summary
- add stable quick-pull results folder with friendly names and manifest
- expose latest quick-pull viewer and counters in the menu dashboard
- document quick-pull outputs and ensure log viewer respects configured log path

## Testing
- `tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68ac67111c008327a3f8f5eb8eecf92f