### PR TITLE
Fix quick pull path and hash generation

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -103,7 +103,7 @@ while true; do
         if [[ -x "$REPO_ROOT/scripts/finalize_quickpull.sh" ]]; then
           echo "[INFO] Finalizing quick pull (friendly names + manifest)..."
           "$REPO_ROOT/scripts/finalize_quickpull.sh" || true
-          qdir="$RESULTS_DIR/$DEV/quick_pull_results"
+          qdir="$RESULTS_DIR/$DEVICE/quick_pull_results"
           if [[ -f "$qdir/manifest.csv" ]]; then
             QUICK_PULL_DIR="$(basename "$qdir")"
             PKGS_FOUND=$(tail -n +2 "$qdir/manifest.csv" | cut -d, -f3 | sort -u | wc -l | tr -d ' ')

--- a/scripts/grab_apks.sh
+++ b/scripts/grab_apks.sh
@@ -124,8 +124,13 @@ pull_one_pkg() {
   done <<< "$paths"
 
   if compgen -G "$pulled/*.apk" >/dev/null; then
-    ( cd "$pulled"
-      if command -v sha256sum >/devnull 2>&1; then sha256sum *.apk > hashes.sha256; else shasum -a 256 *.apk > hashes.sha256; fi
+    (
+      cd "$pulled"
+      if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum *.apk > hashes.sha256
+      else
+        shasum -a 256 *.apk > hashes.sha256
+      fi
     ) || true
   fi
 


### PR DESCRIPTION
## Summary
- use DEVICE var when building quick pull results path
- compute APK hash list without /devnull redirect errors

## Testing
- `bash tests/integration/finalize_quickpull_test.sh`
- `timeout 300 bash tests/run.sh` *(interrupted: hung after adb_health stage)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6e332e9083278ea95d66925c667e